### PR TITLE
KHR_texture_transform extension support

### DIFF
--- a/src/gltf/gltf-parser.ts
+++ b/src/gltf/gltf-parser.ts
@@ -15,6 +15,7 @@ import { Model } from "../model"
 import { TransformMatrix } from "../transform/transform-matrix"
 import { Skin } from "../skinning/skin"
 import { Joint } from "../skinning/joint"
+import { Mat3 } from "../math/mat3"
 
 /**
  * Parses glTF assets and creates models and meshes.
@@ -158,6 +159,36 @@ export class glTFParser {
   }
 
   /**
+   * Calculates uv transform matrix based on "offset", "rotation" and "scale" 
+   * parameters from extension data (if any), and attaches it to texture
+   * @param KHR_texture_transform extension data from gltf file
+   * @param texture Texture to attach generated matrix to
+   */
+  calculateUVTransform(KHR_texture_transform: any, texture: PIXI.Texture) {	  
+    let rotation: Float32Array = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+    let scale: Float32Array = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+    let translation: Float32Array = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+	  
+	  if (KHR_texture_transform.rotation !== undefined) {
+	    const s =  Math.sin(KHR_texture_transform.rotation);
+      const c =  Math.cos(KHR_texture_transform.rotation);		
+	    rotation.set([c, s, 0, -s, c, 0, 0, 0, 1], 0);
+	  }	  
+	  if (KHR_texture_transform.scale !== undefined) {
+      scale.set([KHR_texture_transform.scale[0], 0, 0, 0, KHR_texture_transform.scale[1], 0, 0, 0, 1], 0);
+    }
+    if (KHR_texture_transform.offset !== undefined) {
+      translation.set([1, 0, KHR_texture_transform.offset[0], 0, 1, KHR_texture_transform.offset[1], 0, 0, 1], 0);
+    }
+
+    let uvMatrix: Float32Array = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+    Mat3.multiply(rotation, scale, uvMatrix);
+    Mat3.multiply(uvMatrix, translation, uvMatrix);
+
+    (<any>texture).uvTransform = uvMatrix;
+  }
+
+  /**
    * Returns the texture used by the specified object.
    * @param source The source object or index.
    */
@@ -166,7 +197,11 @@ export class glTFParser {
     if (typeof source === "number") {
       source = { index: source }
     }
-    return this._asset.images[this._descriptor.textures[source.index].source]
+    let texture = this._asset.images[this._descriptor.textures[source.index].source];
+	  if (source.extensions && source.extensions.KHR_texture_transform) {
+	    this.calculateUVTransform(source.extensions.KHR_texture_transform, texture);
+    }    
+    return texture;
   }
 
   /**

--- a/src/material/standard/shader/textures.webgl1.glsl
+++ b/src/material/standard/shader/textures.webgl1.glsl
@@ -90,7 +90,7 @@ vec2 getOcclusionUV()
     vec3 uv = vec3(v_UVCoord1, 1.0);
 #ifdef HAS_OCCLUSION_MAP
     uv.xy = u_OcclusionUVSet < 1 ? v_UVCoord1 : v_UVCoord2;
-    #ifdef HAS_OCCLSION_UV_TRANSFORM
+    #ifdef HAS_OCCLUSION_UV_TRANSFORM
     uv *= u_OcclusionUVTransform;
     #endif
 #endif

--- a/src/material/standard/shader/textures.webgl2.glsl
+++ b/src/material/standard/shader/textures.webgl2.glsl
@@ -90,7 +90,7 @@ vec2 getOcclusionUV()
     vec3 uv = vec3(v_UVCoord1, 1.0);
 #ifdef HAS_OCCLUSION_MAP
     uv.xy = u_OcclusionUVSet < 1 ? v_UVCoord1 : v_UVCoord2;
-    #ifdef HAS_OCCLSION_UV_TRANSFORM
+    #ifdef HAS_OCCLUSION_UV_TRANSFORM
     uv *= u_OcclusionUVTransform;
     #endif
 #endif

--- a/src/material/standard/standard-material-feature-set.ts
+++ b/src/material/standard/standard-material-feature-set.ts
@@ -83,30 +83,45 @@ export namespace StandardMaterialFeatureSet {
       if (!material.baseColorTexture.valid) {
         return undefined
       }
+	    if ((<any>material.baseColorTexture).uvTransform) {
+		    features.push("HAS_BASECOLOR_UV_TRANSFORM 1");
+	    }
       features.push("HAS_BASE_COLOR_MAP 1")
     }
     if (material.emissiveTexture) {
       if (!material.emissiveTexture.valid) {
         return undefined
       }
+	    if ((<any>material.emissiveTexture).uvTransform) {
+		    features.push("HAS_EMISSIVE_UV_TRANSFORM 1");
+	    }
       features.push("HAS_EMISSIVE_MAP 1")
     }
     if (material.normalTexture) {
       if (!material.normalTexture.valid) {
         return undefined
       }
+	    if ((<any>material.normalTexture).uvTransform) {
+		    features.push("HAS_NORMAL_UV_TRANSFORM 1");
+	    }
       features.push("HAS_NORMAL_MAP 1")
     }
     if (material.metallicRoughnessTexture) {
       if (!material.metallicRoughnessTexture.valid) {
         return undefined
       }
+	    if ((<any>material.metallicRoughnessTexture).uvTransform) {
+		    features.push("HAS_METALLICROUGHNESS_UV_TRANSFORM 1");
+	    }
       features.push("HAS_METALLIC_ROUGHNESS_MAP 1")
     }
     if (material.occlusionTexture) {
       if (!material.occlusionTexture.valid) {
         return undefined
       }
+	    if ((<any>material.occlusionTexture).uvTransform) {
+		    features.push("HAS_OCCLUSION_UV_TRANSFORM 1");
+	    }
       features.push("HAS_OCCLUSION_MAP 1")
     }
     switch (material.alphaMode) {

--- a/src/material/standard/standard-material.ts
+++ b/src/material/standard/standard-material.ts
@@ -326,6 +326,9 @@ export class StandardMaterial extends Material {
     if (this.baseColorTexture?.valid) {
       shader.uniforms.u_BaseColorSampler = this.baseColorTexture
       shader.uniforms.u_BaseColorUVSet = 0
+      if ((<any>this.baseColorTexture).uvTransform) {
+        shader.uniforms.u_BaseColorUVTransform = (<any>this.baseColorTexture).uvTransform;
+      }
     }
     let lightingEnvironment = this.lightingEnvironment || LightingEnvironment.main
     for (let i = 0; i < lightingEnvironment.lights.length; i++) {
@@ -357,20 +360,32 @@ export class StandardMaterial extends Material {
       shader.uniforms.u_EmissiveSampler = this.emissiveTexture
       shader.uniforms.u_EmissiveUVSet = 0
       shader.uniforms.u_EmissiveFactor = [1, 1, 1]
+      if ((<any>this.emissiveTexture).uvTransform) {
+        shader.uniforms.u_EmissiveUVTransform = (<any>this.emissiveTexture).uvTransform;
+      }
     }
     if (this.normalTexture?.valid) {
       shader.uniforms.u_NormalSampler = this.normalTexture
       shader.uniforms.u_NormalScale = 1
       shader.uniforms.u_NormalUVSet = 0
+      if ((<any>this.normalTexture).uvTransform) {
+        shader.uniforms.u_NormalUVTransform = (<any>this.normalTexture).uvTransform;
+      }
     }
     if (this.metallicRoughnessTexture?.valid) {
       shader.uniforms.u_MetallicRoughnessSampler = this.metallicRoughnessTexture
       shader.uniforms.u_MetallicRoughnessUVSet = 0
+      if ((<any>this.metallicRoughnessTexture).uvTransform) {
+        shader.uniforms.u_MetallicRoughnessUVTransform = (<any>this.metallicRoughnessTexture).uvTransform;
+      }
     }
     if (this.occlusionTexture?.valid) {
       shader.uniforms.u_OcclusionSampler = this.occlusionTexture
       shader.uniforms.u_OcclusionStrength = 1
       shader.uniforms.u_OcclusionUVSet = 0
+      if ((<any>this.occlusionTexture).uvTransform) {
+        shader.uniforms.u_OcclusionUVTransform = (<any>this.occlusionTexture).uvTransform;
+      }
     }
   }
 }

--- a/src/material/standard/standard-material.ts
+++ b/src/material/standard/standard-material.ts
@@ -259,6 +259,21 @@ export class StandardMaterial extends Material {
       material.occlusionTexture = source.occlusionTexture?.clone()
       material.doubleSided = source.doubleSided
       material.alphaCutoff = source.alphaCutoff
+      if (source.baseColorTexture && (<any>source.baseColorTexture).uvTransform) {
+        (<any>material.baseColorTexture).uvTransform = (<any>source.baseColorTexture).uvTransform; 
+      }
+      if (source.normalTexture && (<any>source.normalTexture).uvTransform) {
+        (<any>material.normalTexture).uvTransform = (<any>source.normalTexture).uvTransform; 
+      }
+      if (source.emissiveTexture && (<any>source.emissiveTexture).uvTransform) {
+        (<any>material.emissiveTexture).uvTransform = (<any>source.emissiveTexture).uvTransform; 
+      }
+      if (source.occlusionTexture && (<any>source.occlusionTexture).uvTransform) {
+        (<any>material.occlusionTexture).uvTransform = (<any>source.occlusionTexture).uvTransform; 
+      }
+      if (source.metallicRoughnessTexture && (<any>source.metallicRoughnessTexture).uvTransform) {
+        (<any>material.metallicRoughnessTexture).uvTransform = (<any>source.metallicRoughnessTexture).uvTransform; 
+      }
     }
     return material
   }

--- a/src/math/mat3.ts
+++ b/src/math/mat3.ts
@@ -1,0 +1,5 @@
+export namespace Mat3 {
+  export function multiply(a: Float32Array, b: Float32Array, out: Float32Array) {    
+	let a00 = a[0], a01 = a[1], a02 = a[2], a10 = a[3], a11 = a[4], a12 = a[5], a20 = a[6], a21 = a[7], a22 = a[8], b00 = b[0], b01 = b[1], b02 = b[2], b10 = b[3], b11 = b[4], b12 = b[5], b20 = b[6], b21 = b[7], b22 = b[8]; out[0] = b00 * a00 + b01 * a10 + b02 * a20, out[1] = b00 * a01 + b01 * a11 + b02 * a21, out[2] = b00 * a02 + b01 * a12 + b02 * a22, out[3] = b10 * a00 + b11 * a10 + b12 * a20, out[4] = b10 * a01 + b11 * a11 + b12 * a21, out[5] = b10 * a02 + b11 * a12 + b12 * a22, out[6] = b20 * a00 + b21 * a10 + b22 * a20, out[7] = b20 * a01 + b21 * a11 + b22 * a21, out[8] = b20 * a02 + b21 * a12 + b22 * a22; return out;
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require("path")
 module.exports = env => {
   return {
     entry: "./src/index.ts",
-    mode: env.production ? "development" : "development",
+    mode: env.production ? "production" : "development",
     devtool: env.production ? "" : "inline-source-map",
     module: {
       rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require("path")
 module.exports = env => {
   return {
     entry: "./src/index.ts",
-    mode: env.production ? "production" : "development",
+    mode: env.production ? "development" : "development",
     devtool: env.production ? "" : "inline-source-map",
     module: {
       rules: [


### PR DESCRIPTION
Adds support for KHR_texture_transform extension. This can be tested with https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/TextureTransformTest