### PR TITLE
Export MaterialRenderSortType for use in creating custom materials

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export { ImageBasedLighting } from "./lighting/image-based-lighting"
 export { StandardPipeline } from "./pipeline/standard-pipeline"
 export { MaterialRenderPass } from "./pipeline/material-render-pass"
 export { Material } from "./material/material"
+export { MaterialRenderSortType } from "./material/material-render-sort-type";
 export { CubemapLoader } from "./loader/cubemap-loader"
 export { Cubemap } from "./cubemap/cubemap"
 export { ShaderSourceLoader } from "./loader/shader-source-loader"


### PR DESCRIPTION
Hello,

Thanks for your work in this repo. This export was missed, which is is required in the creation of certain materials.