### PR TITLE
Loader to use name as identifier rather than url

### DIFF
--- a/src/loader/cubemap-loader.ts
+++ b/src/loader/cubemap-loader.ts
@@ -21,13 +21,13 @@ export const CubemapLoader = {
     let urls = mipmaps.reduce((acc, val) => acc.concat(val), [])
 
     loader.add(urls.filter(url => !loader.resources[url]).map((url) => {
-      return { parentResource: resource, url: url }
+      return { parentResource: resource, name: url, url: url }
     }))
     let completed = 0
 
     // Listen for resources being loaded.
     let binding = loader.onLoad.add((loader: any, res: any) => {
-      if (urls.includes(res.url)) {
+      if (urls.includes(res.name)) {
         if (++completed === urls.length) {
           // All resources used by cubemap has been loaded.
           const textures = mipmaps.map(face => {

--- a/src/loader/gltf-loader.ts
+++ b/src/loader/gltf-loader.ts
@@ -41,7 +41,7 @@ class glTFExternalResourceLoader implements glTFResourceLoader {
     } else {
       // The resource is in queue to be loaded, wait for it.
       let binding = this._loader.onProgress.add((_, resource) => {
-        if (resource.name === url) {
+        if (resource.url === url || resource.name === url) {
           onComplete(resource); binding.detach()
         }
       })

--- a/src/loader/gltf-loader.ts
+++ b/src/loader/gltf-loader.ts
@@ -34,14 +34,14 @@ class glTFExternalResourceLoader implements glTFResourceLoader {
     if (!this._loader.resources[url]) {
       // The resource does not exists and needs to be loaded.
       // @ts-ignore
-      this._loader.add({ parentResource: this._resource, url, onComplete })
+      this._loader.add({ parentResource: this._resource, name: url, url: url, onComplete: onComplete })
     } else if (this._loader.resources[url].data) {
       // The resource already exists, just use that one.
       onComplete(this._loader.resources[url])
     } else {
       // The resource is in queue to be loaded, wait for it.
       let binding = this._loader.onProgress.add((_, resource) => {
-        if (resource.url === url) {
+        if (resource.name === url) {
           onComplete(resource); binding.detach()
         }
       })

--- a/src/mesh/geometry/sphere-geometry.ts
+++ b/src/mesh/geometry/sphere-geometry.ts
@@ -1,0 +1,79 @@
+import { Vec3 } from "../../math/vec3";
+import { MeshGeometry3D } from "./mesh-geometry"
+
+export namespace SphereGeometry {
+  export function create(radius = 1, widthSegments = 32, heightSegments = 16, phiStart = 0, phiLength = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI) {
+
+    // based on
+    // https://github.com/mrdoob/three.js/blob/master/src/geometries/SphereGeometry.js
+    // https://github.com/mrdoob/three.js/blob/dev/LICENSE
+
+    widthSegments = Math.max(3, Math.floor(widthSegments));
+    heightSegments = Math.max(2, Math.floor(heightSegments));
+    const thetaEnd = Math.min(thetaStart + thetaLength, Math.PI);
+    let index = 0;
+    const grid = [];
+    const vertex = Vec3.create();
+    const normal = Vec3.create();
+
+    // buffers
+    const indices = [];
+    const vertices = [];
+    const normals = [];
+    const uvs = [];
+
+    // generate vertices, normals and uvs
+    for (let iy = 0; iy <= heightSegments; iy++) {
+      const verticesRow = [];
+      const v = iy / heightSegments;
+      // special case for the poles
+      let uOffset = 0;
+      if (iy == 0 && thetaStart == 0) {
+        uOffset = 0.5 / widthSegments;
+      } else if (iy == heightSegments && thetaEnd == Math.PI) {
+        uOffset = - 0.5 / widthSegments;
+      }
+      for (let ix = 0; ix <= widthSegments; ix++) {
+        const u = ix / widthSegments;
+        // vertex
+        vertex[0] = - radius * Math.cos(phiStart + u * phiLength) * Math.sin(thetaStart + v * thetaLength);
+        vertex[1] = radius * Math.cos(thetaStart + v * thetaLength);
+        vertex[2] = radius * Math.sin(phiStart + u * phiLength) * Math.sin(thetaStart + v * thetaLength);
+        vertices.push(vertex[0], vertex[1], vertex[2]);
+        // normal
+        Vec3.normalize(vertex, normal);
+        normals.push(normal[0], normal[1], normal[2]);
+        // uv
+        uvs.push(u + uOffset, 1 - v);
+        verticesRow.push(index++);
+      }
+      grid.push(verticesRow);
+    }
+
+    // indices
+    for (let iy = 0; iy < heightSegments; iy++) {
+      for (let ix = 0; ix < widthSegments; ix++) {
+        const a = grid[iy][ix + 1];
+        const b = grid[iy][ix];
+        const c = grid[iy + 1][ix];
+        const d = grid[iy + 1][ix + 1];
+        if (iy !== 0 || thetaStart > 0) indices.push(a, b, d);
+        if (iy !== heightSegments - 1 || thetaEnd < Math.PI) indices.push(b, c, d);
+      }
+    }
+    return Object.assign(new MeshGeometry3D(), {
+      positions: {
+        buffer: new Float32Array(vertices)
+      },
+      indices: {
+        buffer: new Uint16Array(indices)
+      },
+      normals: {
+        buffer: new Float32Array(normals)
+      },
+      uvs: [{
+        buffer: new Float32Array(uvs)
+      }]
+    })
+  }
+}

--- a/src/mesh/geometry/sphere-geometry.ts
+++ b/src/mesh/geometry/sphere-geometry.ts
@@ -2,6 +2,16 @@ import { Vec3 } from "../../math/vec3";
 import { MeshGeometry3D } from "./mesh-geometry"
 
 export namespace SphereGeometry {
+  /**
+   * The geometry is created by sweeping and calculating vertexes around the Y axis (horizontal sweep) and the Z axis (vertical sweep). Thus, incomplete spheres (akin to 'sphere slices') can be created through the use of different values of phiStart, phiLength, thetaStart and thetaLength, in order to define the points in which we start (or end) calculating those vertices.
+   * @param radius Sphere radius. Default is 1.
+   * @param widthSegments Number of horizontal segments. Minimum value is 3, and the default is 32.
+   * @param heightSegments Number of vertical segments. Minimum value is 2, and the default is 16.
+   * @param phiStart Specify horizontal starting angle. Default is 0.
+   * @param phiLength Specify horizontal sweep angle size. Default is Math.PI * 2.
+   * @param thetaStart Specify vertical starting angle. Default is 0.
+   * @param thetaLength Specify vertical sweep angle size. Default is Math.PI.  
+   */
   export function create(radius = 1, widthSegments = 32, heightSegments = 16, phiStart = 0, phiLength = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI) {
 
     // based on

--- a/src/mesh/mesh.ts
+++ b/src/mesh/mesh.ts
@@ -4,6 +4,7 @@ import { CubeGeometry } from "./geometry/cube-geometry"
 import { MeshGeometry3D } from "./geometry/mesh-geometry"
 import { Container3D } from "../container"
 import { QuadGeometry } from "./geometry/quad-geometry"
+import { SphereGeometry } from "./geometry/sphere-geometry"
 import { Skin } from "../skinning/skin"
 import { InstancedMesh3D } from "./instanced-mesh"
 import { Material } from "../material/material"
@@ -172,5 +173,14 @@ export class Mesh3D extends Container3D {
    */
   static createPlane(material: Material = new StandardMaterial()) {
     return new Mesh3D(PlaneGeometry.create(), material)
+  }
+
+  /**
+   * Creates a new sphere mesh with the specified material.
+   * @param material The material to use.
+   */
+  static createSphere(material?: Material, radius = 1, widthSegments = 32, heightSegments = 16, phiStart = 0, phiLength = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI) {
+    material = material || new StandardMaterial();
+    return new Mesh3D(SphereGeometry.create(radius, widthSegments, heightSegments, phiStart, phiLength, thetaStart, thetaLength), material)
   }
 }

--- a/src/mesh/mesh.ts
+++ b/src/mesh/mesh.ts
@@ -178,6 +178,13 @@ export class Mesh3D extends Container3D {
   /**
    * Creates a new sphere mesh with the specified material.
    * @param material The material to use.
+   * @param radius Sphere radius. Default is 1.
+   * @param widthSegments Number of horizontal segments. Minimum value is 3, and the default is 32.
+   * @param heightSegments Number of vertical segments. Minimum value is 2, and the default is 16.
+   * @param phiStart Specify horizontal starting angle. Default is 0.
+   * @param phiLength Specify horizontal sweep angle size. Default is Math.PI * 2.
+   * @param thetaStart Specify vertical starting angle. Default is 0.
+   * @param thetaLength Specify vertical sweep angle size. Default is Math.PI.  
    */
   static createSphere(material?: Material, radius = 1, widthSegments = 32, heightSegments = 16, phiStart = 0, phiLength = Math.PI * 2, thetaStart = 0, thetaLength = Math.PI) {
     material = material || new StandardMaterial();


### PR DESCRIPTION
using resource name (rather than url) as unique identifier allows alternative loaders to preload the assets (e.g. with decaching query strings)