### PR TITLE
support camera distance sorting for billboards

### DIFF
--- a/src/math/vec3.ts
+++ b/src/math/vec3.ts
@@ -40,6 +40,9 @@ export class Vec3 {
   static magnitude(a: Float32Array) {
     return vec3.length(a)
   }
+  static squareMagnitude(a: Float32Array) {
+    return vec3.squaredLength(a)
+  }
   static inverse(a: Float32Array, out = new Float32Array(3)) {
     return <Float32Array>vec3.inverse(out, a)
   }

--- a/src/pipeline/standard-pipeline.ts
+++ b/src/pipeline/standard-pipeline.ts
@@ -108,6 +108,13 @@ export class StandardPipeline extends ObjectRenderer {
       }
       return a.renderSortOrder < b.renderSortOrder ? -1 : 1
     })
+
+    this._sprites.sort((a, b) => {
+      if (a.zIndex !== b.zIndex) {
+        return a.zIndex - b.zIndex;
+      }
+      return b.squareDistanceFromCamera - a.squareDistanceFromCamera;
+    })
   }
 
   /**

--- a/src/sprite/projection-sprite.ts
+++ b/src/sprite/projection-sprite.ts
@@ -4,9 +4,10 @@ import { settings } from "@pixi/settings"
 
 export class ProjectionSprite extends Sprite {
   private _pixelsPerUnit = 100
+  public squareDistanceFromCamera: number = 0;
 
   modelViewProjection = new Float32Array(16)
-  
+
   constructor(texture?: Texture<Resource>) {
     super(texture)
     this.pluginName = "pipeline"

--- a/src/sprite/sprite.ts
+++ b/src/sprite/sprite.ts
@@ -121,7 +121,7 @@ export class Sprite3D extends Container3D {
       this._cameraTransformId = camera.transformId
       const dir = Vec3.subtract(Camera.main.position.array, this.transform.position.array);
       const projection = Vec3.scale(Camera.main.worldTransform.forward, Vec3.dot(dir, Camera.main.worldTransform.forward));
-      this._sprite.squareDistanceFromCamera = Math.pow(projection[0], 2) + Math.pow(projection[1], 2) + Math.pow(projection[2], 2);
+      this._sprite.squareDistanceFromCamera = Vec3.squareMagnitude(projection);
     }
     this._sprite.worldAlpha = this.worldAlpha
     this._sprite.render(renderer)

--- a/src/sprite/sprite.ts
+++ b/src/sprite/sprite.ts
@@ -8,6 +8,7 @@ import { SpriteBillboardType } from "./sprite-billboard-type"
 import { Container3D } from "../container"
 import { Mat4 } from "../math/mat4"
 import { ProjectionSprite } from "./projection-sprite"
+import { Vec3 } from ".."
 
 /**
  * Represents a sprite in 3D space.
@@ -118,6 +119,9 @@ export class Sprite3D extends Container3D {
         this._modelView, this._sprite.modelViewProjection)
       this._parentID = this.transform._worldID
       this._cameraTransformId = camera.transformId
+      const dir = Vec3.subtract(Camera.main.position.array, this.transform.position.array);
+      const projection = Vec3.scale(Camera.main.worldTransform.forward, Vec3.dot(dir, Camera.main.worldTransform.forward));
+      this._sprite.squareDistanceFromCamera = Math.pow(projection[0], 2) + Math.pow(projection[1], 2) + Math.pow(projection[2], 2);
     }
     this._sprite.worldAlpha = this.worldAlpha
     this._sprite.render(renderer)


### PR DESCRIPTION
here we can support sorting sprite3Ds based on billboard distance from the camera

benefit:
- should only update on a camera or sprite transform change

issue:
- Currently treating Sprite3Ds seperately from the draw order of meshes, meaning any transparent meshes will be rendered behind the rendering of sprite3Ds regardless of position in 3D space