### PR TITLE
rendering instances bug fix

### DIFF
--- a/src/material/standard/standard-shader-instancing.ts
+++ b/src/material/standard/standard-shader-instancing.ts
@@ -35,9 +35,6 @@ export class StandardShaderInstancing {
     }
     let bufferIndex = 0
     for (let i = 0; i < instances.length; i++) {
-      if (!instances[i].worldVisible || !instances[i].renderable) {
-        continue
-      }
       const normal = instances[i].transform.normalTransform.array
       for (let j = 0; j < 4; j++) {
         (<Float32Array>this._normalMatrix[j].data)

--- a/src/material/standard/standard-shader.ts
+++ b/src/material/standard/standard-shader.ts
@@ -65,7 +65,12 @@ export class StandardShader extends MeshShader {
 
   render(mesh: Mesh3D, renderer: Renderer, state: State, drawMode: DRAW_MODES) {
     if (mesh.instances.length > 0) {
-      this._instancing.updateBuffers(mesh.instances)
+      const filteredInstances = mesh.instances.filter((instance) => instance.worldVisible && instance.renderable);
+      if (filteredInstances.length === 0) {
+        //early exit - this avoids us drawing the last known instance in the instance buffer
+        return;
+      }
+      this._instancing.updateBuffers(filteredInstances)
     }
     super.render(mesh, renderer, state, drawMode)
   }


### PR DESCRIPTION
Step 1: have 1 or more instances being rendered
Step 2: render at least once
Step 3: set all intances visibility/renderability to false
Step 4: render again

### expected behaviour
all instances are no longer rendered

### what actually happens
whatever instances were visible in the previous frame are still visible

### why?
because the instancing for loop would not make any form of update to the buffers, the buffers will keep the data from the previous frame until at least 1 instance is set to visibile/renderable