### PR TITLE
needed to be based on world transform

### DIFF
--- a/src/sprite/sprite.ts
+++ b/src/sprite/sprite.ts
@@ -120,8 +120,8 @@ export class Sprite3D extends Container3D {
         this._modelView, this._sprite.modelViewProjection)
       this._parentID = this.transform._worldID
       this._cameraTransformId = camera.transformId
-      const dir = Vec3.subtract(camera.position.array, this.transform.position.array, vec3)
-      const projection = Vec3.scale(camera.worldTransform.forward, 
+      const dir = Vec3.subtract(camera.position.array, this.transform.worldTransform.position, vec3)
+      const projection = Vec3.scale(camera.worldTransform.forward,
         Vec3.dot(dir, camera.worldTransform.forward), vec3)
       this._sprite.distanceFromCamera = Vec3.squaredMagnitude(projection)
     }


### PR DESCRIPTION
incorrectly used local transform for what required world transform

### issue
when parented to a container with a change in rotationQuaternion, the orientation of the sprite when measuring distance from the camera would be based on local orientation, not world

### fix
world transform now used