### PR TITLE
Idea for sprite rendering with and without depth testing

### DIFF
--- a/src/pipeline/standard-pipeline.ts
+++ b/src/pipeline/standard-pipeline.ts
@@ -71,15 +71,15 @@ export class StandardPipeline extends ObjectRenderer {
     if (object instanceof ProjectionSprite) {
       if(object.depthTest) {
         if(object.zIndex < 0) {
-          this._beforeMeshDepthSprites.push(object);
+          this._beforeMeshDepthSprites.push(object)
         } else {
-          this._afterMeshDepthSprites.push(object);
+          this._afterMeshDepthSprites.push(object)
         }
       } else {
         if(object.zIndex < 0) {
-          this._beforeMeshSprites.push(object);
+          this._beforeMeshSprites.push(object)
         } else {
-          this._afterMeshSprites.push(object);
+          this._afterMeshSprites.push(object)
         }
       }
     } else {
@@ -93,29 +93,33 @@ export class StandardPipeline extends ObjectRenderer {
 
   private flushSprites(sprites: ProjectionSprite[], depthTest: boolean) {
     if (sprites.length > 0) {
-      this._spriteRenderer.setDepthTest(depthTest);
+      this._spriteRenderer.setDepthTest(depthTest)
       this._spriteRenderer.start()
       for (let sprite of sprites) {
         // @ts-ignore
         this._spriteRenderer.render(sprite)
       }
       this._spriteRenderer.stop()
-      sprites = []
     }
   }
 
   flush() {
     this.sort()
-    this.flushSprites(this._beforeMeshSprites, false);
-    this.flushSprites(this._beforeMeshDepthSprites, true);
+    this.flushSprites(this._beforeMeshSprites, false)
+    this.flushSprites(this._beforeMeshDepthSprites, true)
 
     for (let pass of this.renderPasses) {
       pass.render(this._meshes.filter(mesh => mesh.isRenderPassEnabled(pass.name)))
     }
     this._meshes = []
 
-    this.flushSprites(this._afterMeshDepthSprites, false);
-    this.flushSprites(this._afterMeshSprites, true);
+    this.flushSprites(this._afterMeshDepthSprites, false)
+    this.flushSprites(this._afterMeshSprites, true)
+    
+    this._beforeMeshDepthSprites = []
+    this._beforeMeshSprites = []
+    this._afterMeshDepthSprites = []
+    this._afterMeshSprites = []
 
   }
 
@@ -138,10 +142,10 @@ export class StandardPipeline extends ObjectRenderer {
 
     const spriteSortMethod = (a: ProjectionSprite, b: ProjectionSprite) => {
       if (a.zIndex !== b.zIndex) {
-        return a.zIndex - b.zIndex;
+        return a.zIndex - b.zIndex
       }
-      return b.distanceFromCamera - a.distanceFromCamera;
-    };
+      return b.distanceFromCamera - a.distanceFromCamera
+    }
 
     this._beforeMeshDepthSprites.sort(spriteSortMethod)
     this._beforeMeshSprites.sort(spriteSortMethod)

--- a/src/sprite/projection-sprite.ts
+++ b/src/sprite/projection-sprite.ts
@@ -7,6 +7,7 @@ export class ProjectionSprite extends Sprite {
 
   distanceFromCamera = 0
   modelViewProjection = new Float32Array(16)
+  depthTest = true
 
   constructor(texture?: Texture<Resource>) {
     super(texture)

--- a/src/sprite/sprite-batch-renderer.ts
+++ b/src/sprite/sprite-batch-renderer.ts
@@ -21,6 +21,10 @@ export class SpriteBatchRenderer extends AbstractBatchRenderer {
     })
   }
 
+  public setDepthTest(value: boolean) {
+    this.state.depthTest = value;
+  }
+
   packInterleavedGeometry(element: IBatchableElement, attributeBuffer: ViewableBuffer, indexBuffer: Uint16Array, aIndex: number, iIndex: number) {
     const { uint32View, float32View } = attributeBuffer
     const packedVertices = aIndex / this.vertexSize

--- a/src/sprite/sprite.ts
+++ b/src/sprite/sprite.ts
@@ -10,6 +10,7 @@ import { Container3D } from "../container"
 import { ProjectionSprite } from "./projection-sprite"
 
 const vec3 = new Float32Array(3)
+export const NO_DEPTH_ZINDEX = 100
 
 /**
  * Represents a sprite in 3D space.
@@ -34,6 +35,32 @@ export class Sprite3D extends Container3D {
     super()
     this._sprite = new ProjectionSprite(texture)
     this._sprite.anchor.set(0.5)
+  }
+
+  /**
+   * the zIndex used by the internal projection sprite to determine its draw order
+   * 
+   * - negative values are drawn without depth test before anything else
+   * 
+   * - positive values under 100 are drawn in the world in order of zindex
+   * 
+   * - positive values above 100 are drawn on top of everything else without depth test
+   */
+  public get zIndex() {
+    return this._sprite.zIndex;
+  }
+
+  /**
+   * the zIndex used by the internal projection sprite to determine its draw order
+   * 
+   * - negative values are drawn without depth test before anything else
+   * 
+   * - positive values under 100 are drawn in the world in order of zindex
+   * 
+   * - positive values above 100 are drawn on top of everything else without depth test
+ */
+  public set zIndex(value: number) {
+    this._sprite.zIndex = value;
   }
 
   /**

--- a/src/sprite/sprite.ts
+++ b/src/sprite/sprite.ts
@@ -10,7 +10,6 @@ import { Container3D } from "../container"
 import { ProjectionSprite } from "./projection-sprite"
 
 const vec3 = new Float32Array(3)
-export const NO_DEPTH_ZINDEX = 100
 
 /**
  * Represents a sprite in 3D space.
@@ -37,14 +36,28 @@ export class Sprite3D extends Container3D {
     this._sprite.anchor.set(0.5)
   }
 
+    /**
+     * @default true
+     * @summary determines whether the sprite draws using depth test (using depth checks and writing to the depth buffer)
+   */
+     public get depthTest() {
+      return this._sprite.depthTest;
+    }
+  
+    /**
+     * @default true
+     * @summary determines whether the sprite draws using depth test (using depth checks and writing to the depth buffer)
+   */
+    public set depthTest(value: boolean) {
+      this._sprite.depthTest = value;
+    }
+
   /**
    * the zIndex used by the internal projection sprite to determine its draw order
    * 
-   * - negative values are drawn without depth test before anything else
+   * - negative values are drawn before meshes
    * 
-   * - positive values under 100 are drawn in the world in order of zindex
-   * 
-   * - positive values above 100 are drawn on top of everything else without depth test
+   * - positive values are drawn after meshes
    */
   public get zIndex() {
     return this._sprite.zIndex;
@@ -53,12 +66,10 @@ export class Sprite3D extends Container3D {
   /**
    * the zIndex used by the internal projection sprite to determine its draw order
    * 
-   * - negative values are drawn without depth test before anything else
+   * - negative values are drawn before meshes
    * 
-   * - positive values under 100 are drawn in the world in order of zindex
-   * 
-   * - positive values above 100 are drawn on top of everything else without depth test
- */
+   * - positive values are drawn after meshes
+   */
   public set zIndex(value: number) {
     this._sprite.zIndex = value;
   }


### PR DESCRIPTION
- zIndex of the Sprite3D should return and modify the internal projection sprite zIndex
- zIndex value dictates whether we want to render sprites before/after other scenery without depth test

Not 100% certain that this would be the best way of handling this, thought it'd be best to get your thoughts on the premise at least

### Why?
- this means we can render out sprites without depth testing to get the 3D position but render them out as a form of screen space effect
example draw behind: stars rendered behind everything else to give the impression of moving through space
example draw in front: rain particles that may be constrained to the camera in 3d space and be rendered in front of everything else