### PR TITLE
ToEuler utility method

### DIFF
--- a/src/math/quat.ts
+++ b/src/math/quat.ts
@@ -1,4 +1,5 @@
 import { quat } from "gl-matrix"
+import { RAD_TO_DEG } from 'pixi.js'
 
 export class Quat {
   static set(x: number, y: number, z: number, w: number, out = new Float32Array(4)) {
@@ -18,6 +19,24 @@ export class Quat {
   }
   static fromEuler(x: number, y: number, z: number, out = new Float32Array(4)) {
     return <Float32Array>quat.fromEuler(out, x, y, z)
+  }
+  static toEuler(q: Float32Array, out = new Float32Array(3)) {
+    const x = q[0], y = q[1], z = q[2], w = q[3];
+    const t0 = 2 * (w * x + y * z)
+    const t1 = 1 - 2 * (x * x + y * y)
+    const rollX = Math.atan2(t0, t1) * RAD_TO_DEG;
+
+    let t2 = Math.min(1, Math.max(-1, 2 * (w * y - z * x)))
+    const pitchY = Math.asin(t2) * RAD_TO_DEG;
+
+    const t3 = 2 * (w * z + x * y)
+    const t4 = 1 - 2 * (y * y + z * z)
+    const yawZ = Math.atan2(t3, t4) * RAD_TO_DEG;
+
+    out[0] = rollX;
+    out[1] = pitchY;
+    out[2] = yawZ;
+    return out;
   }
   static conjugate(a: Float32Array, out = new Float32Array(4)) {
     return <Float32Array>quat.conjugate(out, a)

--- a/src/transform/observable-quaternion.ts
+++ b/src/transform/observable-quaternion.ts
@@ -79,7 +79,7 @@ export class ObservableQuaternion extends ObservablePoint {
   }
 
   /** The euler representation of the quaternion. */
-  get euler() {
+  getEulerAngles() {
     return Quat.toEuler(this.array);
   }
 

--- a/src/transform/observable-quaternion.ts
+++ b/src/transform/observable-quaternion.ts
@@ -78,6 +78,11 @@ export class ObservableQuaternion extends ObservablePoint {
     }
   }
 
+  /** The euler representation of the quaternion. */
+  get euler() {
+    return Quat.toEuler(this.array);
+  }
+
   /**
    * Sets the euler angles in degrees.
    * @param x The x angle.


### PR DESCRIPTION
added method to Quat class to calculate the euler representation of a quaternion

I had trouble getting a build locally - I had to add "promise-polyfill" and "object-assign" to the packages array in rollup.build.js in order to succesfully build, not entirely certain the cause just yet, seems to be complaining about the default module export of both object-assign and promise-polyfill modules