### PR TITLE
update to maths utilities

### DIFF
--- a/src/math/quat.ts
+++ b/src/math/quat.ts
@@ -1,7 +1,4 @@
-import { quat, } from "gl-matrix"
-import { RAD_TO_DEG } from "@pixi/math"
-const HALF_PI = Math.PI * 0.5;
-
+import { quat } from "gl-matrix"
 export class Quat {
   static set(x: number, y: number, z: number, w: number, out = new Float32Array(4)) {
     return <Float32Array>quat.set(out, x, y, z, w)
@@ -20,35 +17,6 @@ export class Quat {
   }
   static fromEuler(x: number, y: number, z: number, out = new Float32Array(4)) {
     return <Float32Array>quat.fromEuler(out, x, y, z)
-  }
-  static toEuler(q: Float32Array, out = new Float32Array(3)) {
-    const x = q[0], y = q[1], z = q[2], w = q[3];
-    const sqx = Math.pow(x, 2);
-    const sqy = Math.pow(y, 2);
-    const sqz = Math.pow(z, 2);
-    const sqw = Math.pow(w, 2);
-    const magnitude = sqx + sqy + sqz + sqw;
-    const test = x * y + z * w;
-    if (test > 0.499 * magnitude) { // singularity at north pole
-      out[0] = 0;
-      out[1] = 2 * Math.atan2(x, w) * RAD_TO_DEG;
-      out[2] = HALF_PI * RAD_TO_DEG;
-      return out;
-    }
-    if (test < -0.499 * magnitude) { // singularity at south pole
-      out[0] = 0;
-      out[1] = -2 * Math.atan2(x, w) * RAD_TO_DEG;
-      out[2] = -HALF_PI * RAD_TO_DEG;
-      return out;
-    }
-    const bank = Math.atan2(2 * x * w - 2 * y * z, -sqx + sqy - sqz + sqw);
-    const heading = Math.atan2(2 * y * w - 2 * x * z, sqx - sqy - sqz + sqw);
-    const attitude = Math.asin(2 * test / magnitude);
-    out[0] = bank * RAD_TO_DEG;
-    out[1] = heading * RAD_TO_DEG;
-    out[2] = attitude * RAD_TO_DEG;
-
-    return out;
   }
   static conjugate(a: Float32Array, out = new Float32Array(4)) {
     return <Float32Array>quat.conjugate(out, a)

--- a/src/math/vec3.ts
+++ b/src/math/vec3.ts
@@ -59,6 +59,6 @@ export class Vec3 {
     return vec3.squaredDistance(a, b)
   }
   static lerp(a: Float32Array, b: Float32Array, t: number, out = new Float32Array(3)) {
-    return vec3.lerp(out, a, b, t)
+    return <Float32Array>vec3.lerp(out, a, b, t)
   }
 }

--- a/src/transform/observable-quaternion.ts
+++ b/src/transform/observable-quaternion.ts
@@ -78,11 +78,6 @@ export class ObservableQuaternion extends ObservablePoint {
     }
   }
 
-  /** The euler representation of the quaternion. */
-  getEulerAngles() {
-    return Quat.toEuler(this.array);
-  }
-
   /**
    * Sets the euler angles in degrees.
    * @param x The x angle.


### PR DESCRIPTION
quaternion
- euler method **REMOVED**
- now has a rotationTo method to get the quaternion to rotation between two vectors (helpful method that was hidden behind gl-matrix)

vector
- lerp would return vec3, casting it to float32array to keep return types consistent

quaternion to euler was extremely unreliable in test cases, seems unfitting to provide it as a utility function when it doesn't give exactly what the user would expect