### PR TITLE
shadows can now be rendered with instances

### DIFF
--- a/src/shadow/shader/gaussian-blur.frag
+++ b/src/shadow/shader/gaussian-blur.frag
@@ -1,9 +1,9 @@
 #version VERSION
 
 #ifdef GL_FRAGMENT_PRECISION_HIGH
-precision highp float;
+  precision highp float;
 #else
-precision mediump float;
+  precision mediump float;
 #endif
 
 varying vec2 v_UV1;
@@ -11,17 +11,16 @@ varying vec2 v_UV1;
 uniform vec2 u_BlurScale;
 uniform sampler2D u_FilterSampler;
 
-void main()
-{
-    vec4 color = vec4(0.0);
+void main() {
+  vec4 color = vec4(0.0);
 
-    color += texture2D(u_FilterSampler, v_UV1 + (vec2(-3.0) * u_BlurScale.xy)) * (1.0 / 64.0);
-    color += texture2D(u_FilterSampler, v_UV1 + (vec2(-2.0) * u_BlurScale.xy)) * (6.0 / 64.0);
-    color += texture2D(u_FilterSampler, v_UV1 + (vec2(-1.0) * u_BlurScale.xy)) * (15.0 / 64.0);
-    color += texture2D(u_FilterSampler, v_UV1 + (vec2(+0.0) * u_BlurScale.xy)) * (20.0 / 64.0);
-    color += texture2D(u_FilterSampler, v_UV1 + (vec2(+1.0) * u_BlurScale.xy)) * (15.0 / 64.0);
-    color += texture2D(u_FilterSampler, v_UV1 + (vec2(+2.0) * u_BlurScale.xy)) * (6.0 / 64.0);
-    color += texture2D(u_FilterSampler, v_UV1 + (vec2(+3.0) * u_BlurScale.xy)) * (1.0 / 64.0);
+  color += texture2D(u_FilterSampler, v_UV1 + (vec2(-3.0) * u_BlurScale.xy)) * (1.0/64.0);
+  color += texture2D(u_FilterSampler, v_UV1 + (vec2(-2.0) * u_BlurScale.xy)) * (6.0/64.0);
+  color += texture2D(u_FilterSampler, v_UV1 + (vec2(-1.0) * u_BlurScale.xy)) * (15.0/64.0);
+  color += texture2D(u_FilterSampler, v_UV1 + (vec2(+0.0) * u_BlurScale.xy)) * (20.0/64.0);
+  color += texture2D(u_FilterSampler, v_UV1 + (vec2(+1.0) * u_BlurScale.xy)) * (15.0/64.0);
+  color += texture2D(u_FilterSampler, v_UV1 + (vec2(+2.0) * u_BlurScale.xy)) * (6.0/64.0);
+  color += texture2D(u_FilterSampler, v_UV1 + (vec2(+3.0) * u_BlurScale.xy)) * (1.0/64.0);
 
-    gl_FragColor = color;
+  gl_FragColor = color;
 }

--- a/src/shadow/shader/gaussian-blur.frag
+++ b/src/shadow/shader/gaussian-blur.frag
@@ -1,9 +1,9 @@
-#version 100
+#version VERSION
 
 #ifdef GL_FRAGMENT_PRECISION_HIGH
-  precision highp float;
+precision highp float;
 #else
-  precision mediump float;
+precision mediump float;
 #endif
 
 varying vec2 v_UV1;
@@ -11,16 +11,17 @@ varying vec2 v_UV1;
 uniform vec2 u_BlurScale;
 uniform sampler2D u_FilterSampler;
 
-void main() {
-  vec4 color = vec4(0.0);
+void main()
+{
+    vec4 color = vec4(0.0);
 
-  color += texture2D(u_FilterSampler, v_UV1 + (vec2(-3.0) * u_BlurScale.xy)) * (1.0/64.0);
-  color += texture2D(u_FilterSampler, v_UV1 + (vec2(-2.0) * u_BlurScale.xy)) * (6.0/64.0);
-  color += texture2D(u_FilterSampler, v_UV1 + (vec2(-1.0) * u_BlurScale.xy)) * (15.0/64.0);
-  color += texture2D(u_FilterSampler, v_UV1 + (vec2(+0.0) * u_BlurScale.xy)) * (20.0/64.0);
-  color += texture2D(u_FilterSampler, v_UV1 + (vec2(+1.0) * u_BlurScale.xy)) * (15.0/64.0);
-  color += texture2D(u_FilterSampler, v_UV1 + (vec2(+2.0) * u_BlurScale.xy)) * (6.0/64.0);
-  color += texture2D(u_FilterSampler, v_UV1 + (vec2(+3.0) * u_BlurScale.xy)) * (1.0/64.0);
+    color += texture2D(u_FilterSampler, v_UV1 + (vec2(-3.0) * u_BlurScale.xy)) * (1.0 / 64.0);
+    color += texture2D(u_FilterSampler, v_UV1 + (vec2(-2.0) * u_BlurScale.xy)) * (6.0 / 64.0);
+    color += texture2D(u_FilterSampler, v_UV1 + (vec2(-1.0) * u_BlurScale.xy)) * (15.0 / 64.0);
+    color += texture2D(u_FilterSampler, v_UV1 + (vec2(+0.0) * u_BlurScale.xy)) * (20.0 / 64.0);
+    color += texture2D(u_FilterSampler, v_UV1 + (vec2(+1.0) * u_BlurScale.xy)) * (15.0 / 64.0);
+    color += texture2D(u_FilterSampler, v_UV1 + (vec2(+2.0) * u_BlurScale.xy)) * (6.0 / 64.0);
+    color += texture2D(u_FilterSampler, v_UV1 + (vec2(+3.0) * u_BlurScale.xy)) * (1.0 / 64.0);
 
-  gl_FragColor = color;
+    gl_FragColor = color;
 }

--- a/src/shadow/shader/gaussian-blur.vert
+++ b/src/shadow/shader/gaussian-blur.vert
@@ -7,6 +7,6 @@ varying vec2 v_UV1;
 
 void main()
 {
-    v_UV1 = a_UV1;
-    gl_Position = vec4(a_Position, 1.0);
+  v_UV1 = a_UV1;
+  gl_Position = vec4(a_Position, 1.0);
 }

--- a/src/shadow/shader/gaussian-blur.vert
+++ b/src/shadow/shader/gaussian-blur.vert
@@ -1,11 +1,12 @@
-#version 100
+#version VERSION
 
 attribute vec3 a_Position;
 attribute vec2 a_UV1;
 
 varying vec2 v_UV1;
 
-void main() {
-  v_UV1 = a_UV1;
-  gl_Position = vec4(a_Position, 1.0);
+void main()
+{
+    v_UV1 = a_UV1;
+    gl_Position = vec4(a_Position, 1.0);
 }

--- a/src/shadow/shader/gaussian-blur.vert
+++ b/src/shadow/shader/gaussian-blur.vert
@@ -5,8 +5,7 @@ attribute vec2 a_UV1;
 
 varying vec2 v_UV1;
 
-void main()
-{
+void main() {
   v_UV1 = a_UV1;
   gl_Position = vec4(a_Position, 1.0);
 }

--- a/src/shadow/shader/shadow.frag
+++ b/src/shadow/shader/shadow.frag
@@ -3,22 +3,21 @@
 #extension GL_OES_standard_derivatives : enable
 
 #ifdef GL_FRAGMENT_PRECISION_HIGH
-precision highp float;
+    precision highp float;
 #else
-precision mediump float;
+    precision mediump float;
 #endif
 
-void main()
-{
-    float depth = gl_FragCoord.z;
-    float dx = 0.0;
-    float dy = 0.0;
+void main() {
+  float depth = gl_FragCoord.z;
+  float dx = 0.0;
+  float dy = 0.0;
 
   #ifdef GL_OES_standard_derivatives
     dx = dFdx(depth);
     dy = dFdy(depth);
   #endif
 
-    float moment2 = depth * depth + 0.25 * (dx * dx + dy * dy);
-    gl_FragColor = vec4(1.0 - depth, 1.0 - moment2, 0.0, 0.0);
+  float moment2 = depth * depth + 0.25 * (dx * dx + dy * dy);
+  gl_FragColor = vec4(1.0 - depth, 1.0 - moment2, 0.0, 0.0);
 }

--- a/src/shadow/shader/shadow.frag
+++ b/src/shadow/shader/shadow.frag
@@ -3,9 +3,9 @@
 #extension GL_OES_standard_derivatives : enable
 
 #ifdef GL_FRAGMENT_PRECISION_HIGH
-    precision highp float;
+  precision highp float;
 #else
-    precision mediump float;
+  precision mediump float;
 #endif
 
 void main() {

--- a/src/shadow/shader/shadow.frag
+++ b/src/shadow/shader/shadow.frag
@@ -1,23 +1,24 @@
-#version 100
+#version VERSION
 
 #extension GL_OES_standard_derivatives : enable
 
 #ifdef GL_FRAGMENT_PRECISION_HIGH
-  precision highp float;
+precision highp float;
 #else
-  precision mediump float;
+precision mediump float;
 #endif
 
-void main() {
-  float depth = gl_FragCoord.z;
-  float dx = 0.0;
-  float dy = 0.0;
+void main()
+{
+    float depth = gl_FragCoord.z;
+    float dx = 0.0;
+    float dy = 0.0;
 
   #ifdef GL_OES_standard_derivatives
     dx = dFdx(depth);
     dy = dFdy(depth);
   #endif
 
-  float moment2 = depth * depth + 0.25 * (dx * dx + dy * dy);
-  gl_FragColor = vec4(1.0 - depth, 1.0 - moment2, 0.0, 0.0);
+    float moment2 = depth * depth + 0.25 * (dx * dx + dy * dy);
+    gl_FragColor = vec4(1.0 - depth, 1.0 - moment2, 0.0, 0.0);
 }

--- a/src/shadow/shader/shadow.vert
+++ b/src/shadow/shader/shadow.vert
@@ -1,4 +1,4 @@
-#version 100
+#version VERSION
 
 #define FEATURES
 
@@ -14,10 +14,17 @@ uniform mat4 u_ModelMatrix;
 
 #ifdef USE_SKINNING
   #ifdef USE_SKINNING_TEXTURE
-    uniform sampler2D u_jointMatrixSampler;
+uniform sampler2D u_jointMatrixSampler;
   #else
-    uniform mat4 u_jointMatrix[MAX_JOINT_COUNT];
+uniform mat4 u_jointMatrix[MAX_JOINT_COUNT];
   #endif
+#endif
+
+#ifdef USE_INSTANCING
+VERT_IN vec4 a_ModelMatrix0;
+VERT_IN vec4 a_ModelMatrix1;
+VERT_IN vec4 a_ModelMatrix2;
+VERT_IN vec4 a_ModelMatrix3;
 #endif
 
 // these offsets assume the texture is 4 pixels across
@@ -27,36 +34,37 @@ uniform mat4 u_ModelMatrix;
 #define ROW3_U ((0.5 + 3.0) / 4.0)
 
 #ifdef USE_SKINNING
-mat4 getJointMatrix(float boneNdx) {
+mat4 getJointMatrix(float boneNdx)
+{
     #ifdef USE_SKINNING_TEXTURE
-    float v = (boneNdx + 0.5) / float(MAX_JOINT_COUNT);
-    return mat4(
-        texture2D(u_jointMatrixSampler, vec2(ROW0_U, v)),
-        texture2D(u_jointMatrixSampler, vec2(ROW1_U, v)),
-        texture2D(u_jointMatrixSampler, vec2(ROW2_U, v)),
-        texture2D(u_jointMatrixSampler, vec2(ROW3_U, v))
-    );
+float v = (boneNdx + 0.5) / float(MAX_JOINT_COUNT);
+return mat4(texture2D(u_jointMatrixSampler, vec2(ROW0_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW1_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW2_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW3_U, v)));
     #else
-    return u_jointMatrix[int(boneNdx)];
+return u_jointMatrix[int(boneNdx)];
     #endif
 }
 
 mat4 getSkinningMatrix()
 {
-    mat4 skin = mat4(0);
-    skin +=
-        a_Weight1.x * getJointMatrix(a_Joint1.x) +
-        a_Weight1.y * getJointMatrix(a_Joint1.y) +
-        a_Weight1.z * getJointMatrix(a_Joint1.z) +
-        a_Weight1.w * getJointMatrix(a_Joint1.w);
-    return skin;
+mat4 skin = mat4(0);
+skin += a_Weight1.x * getJointMatrix(a_Joint1.x) +
+    a_Weight1.y * getJointMatrix(a_Joint1.y) +
+    a_Weight1.z * getJointMatrix(a_Joint1.z) +
+    a_Weight1.w * getJointMatrix(a_Joint1.w);
+return skin;
 }
 #endif
 
-void main() {
-  vec4 pos = vec4(a_Position, 1.0);
-  #ifdef USE_SKINNING
-    pos = getSkinningMatrix() * pos;
+void main()
+{
+mat4 modelMatrix = u_ModelMatrix;
+  #ifdef USE_INSTANCING
+modelMatrix = mat4(a_ModelMatrix0, a_ModelMatrix1, a_ModelMatrix2, a_ModelMatrix3);
   #endif
-  gl_Position = u_ViewProjectionMatrix * u_ModelMatrix * pos;
+
+vec4 pos = vec4(a_Position, 1.0);
+  #ifdef USE_SKINNING
+pos = getSkinningMatrix() * pos;
+  #endif
+gl_Position = u_ViewProjectionMatrix * modelMatrix * pos;
 }

--- a/src/shadow/shader/shadow.vert
+++ b/src/shadow/shader/shadow.vert
@@ -37,7 +37,12 @@ uniform mat4 u_ModelMatrix;
 mat4 getJointMatrix(float boneNdx) {
   #ifdef USE_SKINNING_TEXTURE
     float v = (boneNdx + 0.5) / float(MAX_JOINT_COUNT);
-    return mat4(texture2D(u_jointMatrixSampler, vec2(ROW0_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW1_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW2_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW3_U, v)));
+    return mat4(
+      texture2D(u_jointMatrixSampler, vec2(ROW0_U, v)), 
+      texture2D(u_jointMatrixSampler, vec2(ROW1_U, v)), 
+      texture2D(u_jointMatrixSampler, vec2(ROW2_U, v)), 
+      texture2D(u_jointMatrixSampler, vec2(ROW3_U, v))
+    );
   #else
     return u_jointMatrix[int(boneNdx)];
   #endif
@@ -45,7 +50,8 @@ mat4 getJointMatrix(float boneNdx) {
 
 mat4 getSkinningMatrix() {
   mat4 skin = mat4(0);
-  skin += a_Weight1.x * getJointMatrix(a_Joint1.x) +
+  skin += 
+    a_Weight1.x * getJointMatrix(a_Joint1.x) +
     a_Weight1.y * getJointMatrix(a_Joint1.y) +
     a_Weight1.z * getJointMatrix(a_Joint1.z) +
     a_Weight1.w * getJointMatrix(a_Joint1.w);
@@ -58,7 +64,6 @@ void main() {
   #ifdef USE_INSTANCING
     modelMatrix = mat4(a_ModelMatrix0, a_ModelMatrix1, a_ModelMatrix2, a_ModelMatrix3);
   #endif
-
   vec4 pos = vec4(a_Position, 1.0);
   #ifdef USE_SKINNING
     pos = getSkinningMatrix() * pos;

--- a/src/shadow/shader/shadow.vert
+++ b/src/shadow/shader/shadow.vert
@@ -5,8 +5,8 @@
 attribute vec3 a_Position;
 
 #ifdef USE_SKINNING
-attribute vec4 a_Joint1;
-attribute vec4 a_Weight1;
+  attribute vec4 a_Joint1;
+  attribute vec4 a_Weight1;
 #endif
 
 uniform mat4 u_ViewProjectionMatrix;
@@ -14,17 +14,17 @@ uniform mat4 u_ModelMatrix;
 
 #ifdef USE_SKINNING
   #ifdef USE_SKINNING_TEXTURE
-uniform sampler2D u_jointMatrixSampler;
+    uniform sampler2D u_jointMatrixSampler;
   #else
-uniform mat4 u_jointMatrix[MAX_JOINT_COUNT];
+    uniform mat4 u_jointMatrix[MAX_JOINT_COUNT];
   #endif
 #endif
 
 #ifdef USE_INSTANCING
-VERT_IN vec4 a_ModelMatrix0;
-VERT_IN vec4 a_ModelMatrix1;
-VERT_IN vec4 a_ModelMatrix2;
-VERT_IN vec4 a_ModelMatrix3;
+  VERT_IN vec4 a_ModelMatrix0;
+  VERT_IN vec4 a_ModelMatrix1;
+  VERT_IN vec4 a_ModelMatrix2;
+  VERT_IN vec4 a_ModelMatrix3;
 #endif
 
 // these offsets assume the texture is 4 pixels across
@@ -34,37 +34,34 @@ VERT_IN vec4 a_ModelMatrix3;
 #define ROW3_U ((0.5 + 3.0) / 4.0)
 
 #ifdef USE_SKINNING
-mat4 getJointMatrix(float boneNdx)
-{
-    #ifdef USE_SKINNING_TEXTURE
-float v = (boneNdx + 0.5) / float(MAX_JOINT_COUNT);
-return mat4(texture2D(u_jointMatrixSampler, vec2(ROW0_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW1_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW2_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW3_U, v)));
-    #else
-return u_jointMatrix[int(boneNdx)];
-    #endif
+mat4 getJointMatrix(float boneNdx) {
+  #ifdef USE_SKINNING_TEXTURE
+    float v = (boneNdx + 0.5) / float(MAX_JOINT_COUNT);
+    return mat4(texture2D(u_jointMatrixSampler, vec2(ROW0_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW1_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW2_U, v)), texture2D(u_jointMatrixSampler, vec2(ROW3_U, v)));
+  #else
+    return u_jointMatrix[int(boneNdx)];
+  #endif
 }
 
-mat4 getSkinningMatrix()
-{
-mat4 skin = mat4(0);
-skin += a_Weight1.x * getJointMatrix(a_Joint1.x) +
+mat4 getSkinningMatrix() {
+  mat4 skin = mat4(0);
+  skin += a_Weight1.x * getJointMatrix(a_Joint1.x) +
     a_Weight1.y * getJointMatrix(a_Joint1.y) +
     a_Weight1.z * getJointMatrix(a_Joint1.z) +
     a_Weight1.w * getJointMatrix(a_Joint1.w);
-return skin;
+  return skin;
 }
 #endif
 
-void main()
-{
-mat4 modelMatrix = u_ModelMatrix;
+void main() {
+  mat4 modelMatrix = u_ModelMatrix;
   #ifdef USE_INSTANCING
-modelMatrix = mat4(a_ModelMatrix0, a_ModelMatrix1, a_ModelMatrix2, a_ModelMatrix3);
+    modelMatrix = mat4(a_ModelMatrix0, a_ModelMatrix1, a_ModelMatrix2, a_ModelMatrix3);
   #endif
 
-vec4 pos = vec4(a_Position, 1.0);
+  vec4 pos = vec4(a_Position, 1.0);
   #ifdef USE_SKINNING
-pos = getSkinningMatrix() * pos;
+    pos = getSkinningMatrix() * pos;
   #endif
-gl_Position = u_ViewProjectionMatrix * modelMatrix * pos;
+  gl_Position = u_ViewProjectionMatrix * modelMatrix * pos;
 }

--- a/src/shadow/shadow-renderer.ts
+++ b/src/shadow/shadow-renderer.ts
@@ -13,11 +13,13 @@ export class ShadowRenderer {
     depthTest: true, clockwiseFrontFace: false, culling: true, blendMode: BLEND_MODES.NONE
   })
   private _shadowShader: ShadowShader
+  private _instancedShadowShader: ShadowShader
   private _skinningShader?: SkinningShader
   private _textureShader?: TextureShader
 
   constructor(public renderer: Renderer) {
     this._shadowShader = new ShadowShader(this.renderer)
+    this._instancedShadowShader = new ShadowShader(this.renderer, ["USE_INSTANCING 1"])
   }
 
   getSkinningShader() {
@@ -34,7 +36,8 @@ export class ShadowRenderer {
   }
 
   render(mesh: Mesh3D, shadowCastingLight: ShadowCastingLight) {
-    let shader: ShadowShader | undefined = this._shadowShader
+    const useInstances = mesh.instances.length > 0;
+    let shader: ShadowShader | undefined = useInstances ? this._instancedShadowShader : this._shadowShader;
     if (mesh.skin) {
       let skinningShader = this.getSkinningShader()
       if (skinningShader && mesh.skin.joints.length > skinningShader.maxSupportedJoints) {

--- a/src/shadow/shadow-shader-instancing.ts
+++ b/src/shadow/shadow-shader-instancing.ts
@@ -1,0 +1,47 @@
+import { Buffer, Geometry } from "@pixi/core"
+import { InstancedMesh3D } from ".."
+
+export class ShadowShaderInstancing {
+  private _maxInstances = 20
+
+  private _modelMatrix: Buffer[] = [
+    new Buffer(), new Buffer(), new Buffer(), new Buffer()
+  ]
+
+  constructor() {
+    this.expandBuffers(this._maxInstances)
+  }
+
+  expandBuffers(instanceCount: number) {
+    while (instanceCount > this._maxInstances) {
+      this._maxInstances += Math.floor(this._maxInstances * 0.5)
+    }
+    for (let i = 0; i < 4; i++) {
+      this._modelMatrix[i].update(new Float32Array(4 * this._maxInstances))
+    }
+  }
+
+  updateBuffers(instances: InstancedMesh3D[]) {
+    if (instances.length > this._maxInstances) {
+      this.expandBuffers(instances.length)
+    }
+    for (let i = 0; i < instances.length; i++) {
+      const model = instances[i].worldTransform.array
+      for (let j = 0; j < 4; j++) {
+        (<Float32Array>this._modelMatrix[j].data)
+          .set(model.slice(j * 4, j * 4 + 4), i * 4)
+      }
+    }
+
+    for (let i = 0; i < 4; i++) {
+      this._modelMatrix[i].update()
+    }
+  }
+
+  addGeometryAttributes(geometry: Geometry) {
+    for (let i = 0; i < 4; i++) {
+      geometry.addAttribute(`a_ModelMatrix${i}`,
+        this._modelMatrix[i], 4, false, undefined, 0, undefined, true)
+    }
+  }
+}

--- a/src/shadow/shadow-shader.ts
+++ b/src/shadow/shadow-shader.ts
@@ -1,4 +1,4 @@
-import { Renderer, Program, Geometry, Buffer } from "@pixi/core"
+import { Renderer, Program, Geometry, State, Buffer } from "@pixi/core"
 import { MeshGeometry3D } from "../mesh/geometry/mesh-geometry"
 import { MeshShader } from "../mesh/mesh-shader"
 import { StandardShaderSource } from "../material/standard/standard-shader-source"
@@ -6,8 +6,11 @@ import { Mesh3D } from "../mesh/mesh"
 import { ShadowCastingLight } from "./shadow-casting-light"
 import { Shader as Vertex } from "./shader/shadow.vert"
 import { Shader as Fragment } from "./shader/shadow.frag"
+import { ShadowShaderInstancing } from "./shadow-shader-instancing"
 
 export class ShadowShader extends MeshShader {
+  private _instancing = new ShadowShaderInstancing();
+
   constructor(renderer: Renderer, features: string[] = []) {
     super(Program.from(
       StandardShaderSource.build(Vertex.source, features, renderer),
@@ -18,11 +21,11 @@ export class ShadowShader extends MeshShader {
     return 0
   }
 
-  createShaderGeometry(geometry: MeshGeometry3D) {
+  createShaderGeometry(geometry: MeshGeometry3D, instanced: boolean) {
     let result = new Geometry()
     if (geometry.indices) {
       if (geometry.indices.buffer.BYTES_PER_ELEMENT === 1) {
-        // PIXI seems to have problems with Uint8Array, let's convert to UNSIGNED_SHORT.
+        // PixiJS seems to have problems with Uint8Array, let's convert to UNSIGNED_SHORT.
         result.addIndex(new Buffer(new Uint16Array(geometry.indices.buffer)))
       } else {
         result.addIndex(new Buffer(geometry.indices.buffer))
@@ -32,11 +35,27 @@ export class ShadowShader extends MeshShader {
       result.addAttribute("a_Position", new Buffer(geometry.positions.buffer),
         3, false, geometry.positions.componentType, geometry.positions.stride)
     }
+    if (instanced) {
+      this._instancing.addGeometryAttributes(result)
+    }
+
     return result
   }
 
   get name() {
     return "shadow-shader"
+  }
+
+  render(mesh: Mesh3D, renderer: Renderer, state: State) {
+    if (mesh.instances.length > 0) {
+      const filteredInstances = mesh.instances.filter((instance) => instance.worldVisible && instance.renderable);
+      if (filteredInstances.length === 0) {
+        //early exit - this avoids us drawing the last known instance in the instance buffer
+        return;
+      }
+      this._instancing.updateBuffers(filteredInstances)
+    }
+    super.render(mesh, renderer, state)
   }
 
   updateUniforms(mesh: Mesh3D, shadowCastingLight: ShadowCastingLight) {

--- a/src/shadow/skinning-shader.ts
+++ b/src/shadow/skinning-shader.ts
@@ -28,8 +28,8 @@ export class SkinningShader extends ShadowShader {
     this._maxSupportedJoints = maxJointCount
   }
 
-  createShaderGeometry(geometry: MeshGeometry3D) {
-    let result = super.createShaderGeometry(geometry)
+  createShaderGeometry(geometry: MeshGeometry3D, instanced: boolean) {
+    let result = super.createShaderGeometry(geometry, instanced)
     if (geometry.joints) {
       result.addAttribute("a_Joint1", new Buffer(geometry.joints.buffer),
         4, false, geometry.joints.componentType, geometry.joints.stride)

--- a/src/shadow/texture-shader.ts
+++ b/src/shadow/texture-shader.ts
@@ -26,8 +26,8 @@ export class TextureShader extends ShadowShader {
       new StandardMaterialMatrixTexture(MAX_SUPPORTED_JOINTS)
   }
 
-  createShaderGeometry(geometry: MeshGeometry3D) {
-    let result = super.createShaderGeometry(geometry)
+  createShaderGeometry(geometry: MeshGeometry3D, instanced: boolean) {
+    let result = super.createShaderGeometry(geometry, instanced)
     if (geometry.joints) {
       result.addAttribute("a_Joint1", new Buffer(geometry.joints.buffer),
         4, false, geometry.joints.componentType, geometry.joints.stride)


### PR DESCRIPTION
Shadows for instances can be rendered in a single pass, cutting calls drastically if you had to use a new mesh3d for every mesh you wanted shadows on.

Issue I see with this: skinning and texture shader that extend the shadow shader won't include instancing.
I don't see this as a major problem as skinned meshes and animations in general don't apply to instances (I'm interested to see what can be done about animations on instances)