### PR TITLE
added texture UV instancing

### DIFF
--- a/src/material/standard/instanced-standard-material.ts
+++ b/src/material/standard/instanced-standard-material.ts
@@ -1,13 +1,27 @@
+import { TextureTransform } from "../..";
 import { Color } from "../../color"
 import { StandardMaterial } from "./standard-material"
+import { StandardMaterialTexture } from "./standard-material-texture"
 
 /** Material for instanced meshes which uses the standard material. */
 export class InstancedStandardMaterial {
   /** The base color of the material. */
   baseColor: Color
+  private _instanceTexture: StandardMaterialTexture | undefined;
+
+  public set instanceTexture(texture: StandardMaterialTexture | undefined) {
+    if (!texture?.transform && texture?.frame && !texture?.noFrame) {
+      texture.transform = TextureTransform.fromTexture(texture)
+    }
+    this._instanceTexture = texture;
+  }
+  public get instanceTexture(): StandardMaterialTexture | undefined {
+    return this._instanceTexture;
+  }
 
   /** Creates a new instanced standard material from the specified material. */
-  constructor(material: StandardMaterial) {
-    this.baseColor = new Color(...material.baseColor.rgba)
+  constructor(public readonly referenceMaterial: StandardMaterial) {
+    this.baseColor = new Color(...referenceMaterial.baseColor.rgba)
+    this.instanceTexture = referenceMaterial.baseColorTexture;
   }
 }

--- a/src/material/standard/instanced-standard-material.ts
+++ b/src/material/standard/instanced-standard-material.ts
@@ -1,4 +1,3 @@
-import { TextureTransform } from "../..";
 import { Color } from "../../color"
 import { StandardMaterial } from "./standard-material"
 import { StandardMaterialTexture } from "./standard-material-texture"
@@ -7,21 +6,33 @@ import { StandardMaterialTexture } from "./standard-material-texture"
 export class InstancedStandardMaterial {
   /** The base color of the material. */
   baseColor: Color
-  private _instanceTexture: StandardMaterialTexture | undefined;
+  private _instanceTexture: StandardMaterialTexture | undefined
+  private _instanceTextureIndex: number = -1
 
   public set instanceTexture(texture: StandardMaterialTexture | undefined) {
-    if (!texture?.transform && texture?.frame && !texture?.noFrame) {
-      texture.transform = TextureTransform.fromTexture(texture)
+    if (texture) {
+      const index = this.referenceMaterial.textureIndicesMap.get(texture);
+      if (!index) {
+        //texture is not part of the spritesheet
+      }
+      console.log('setting instance texture: ', index, texture, this.referenceMaterial.textureIndicesMap);
+      this._instanceTextureIndex = index || -1
+    } else {
+      this._instanceTextureIndex = -1
     }
     this._instanceTexture = texture;
   }
   public get instanceTexture(): StandardMaterialTexture | undefined {
-    return this._instanceTexture;
+    return this._instanceTexture
+  }
+
+  public get instanceTextureIndex() {
+    return this._instanceTextureIndex > -1 ? this._instanceTextureIndex : this.referenceMaterial.textureIndex
   }
 
   /** Creates a new instanced standard material from the specified material. */
   constructor(public readonly referenceMaterial: StandardMaterial) {
     this.baseColor = new Color(...referenceMaterial.baseColor.rgba)
-    this.instanceTexture = referenceMaterial.baseColorTexture;
+    this.instanceTexture = referenceMaterial.baseColorTexture
   }
 }

--- a/src/material/standard/shader/metallic-roughness.frag
+++ b/src/material/standard/shader/metallic-roughness.frag
@@ -363,7 +363,7 @@ void main()
 #endif
 
 #ifdef MATERIAL_UNLIT
-    FRAG_COLOR = vec4(LINEARtoSRGB(baseColor.rgb) * baseColor.a, baseColor.a);
+    FRAG_COLOR = vec4(LINEARtoSRGB(baseColor.rgb), baseColor.a);
     return;
 #endif
 

--- a/src/material/standard/shader/primitive.vert
+++ b/src/material/standard/shader/primitive.vert
@@ -5,69 +5,71 @@
 @import ./extensions;
 @import ./animation;
 
+#ifdef HAS_SPRITESHEET
+  uniform float u_BaseColorUVIndex;  
+  #ifdef USE_INSTANCING
+    VERT_IN float a_BaseColorUVIndex;
+  #endif
+  VERT_OUT float v_BaseColorUVIndex;
+#endif
+
 VERT_IN vec4 a_Position;
 VERT_OUT vec3 v_Position;
 
 #ifdef USE_INSTANCING
-VERT_IN vec4 a_ModelMatrix0;
-VERT_IN vec4 a_ModelMatrix1;
-VERT_IN vec4 a_ModelMatrix2;
-VERT_IN vec4 a_ModelMatrix3;
+  VERT_IN vec4 a_ModelMatrix0;
+  VERT_IN vec4 a_ModelMatrix1;
+  VERT_IN vec4 a_ModelMatrix2;
+  VERT_IN vec4 a_ModelMatrix3;
 #endif
 
 #ifdef USE_INSTANCING
-VERT_IN vec4 a_BaseColorFactor;
-VERT_OUT vec4 v_BaseColorFactor;
-    #ifdef HAS_BASE_COLOR_MAP
-    VERT_IN vec3 a_BaseColorUVTransform0;
-    VERT_IN vec3 a_BaseColorUVTransform1;
-    VERT_IN vec3 a_BaseColorUVTransform2;
-    VERT_OUT mat3 v_BaseColorUVTransform;
-    #endif
+  VERT_IN vec4 a_BaseColorFactor;
+  VERT_OUT vec4 v_BaseColorFactor;
 #endif
 
 #ifdef USE_INSTANCING
-VERT_IN vec4 a_NormalMatrix0;
-VERT_IN vec4 a_NormalMatrix1;
-VERT_IN vec4 a_NormalMatrix2;
-VERT_IN vec4 a_NormalMatrix3;
+  VERT_IN vec4 a_NormalMatrix0;
+  VERT_IN vec4 a_NormalMatrix1;
+  VERT_IN vec4 a_NormalMatrix2;
+  VERT_IN vec4 a_NormalMatrix3;
 #endif
 
 #ifdef HAS_NORMALS
-VERT_IN vec4 a_Normal;
+  VERT_IN vec4 a_Normal;
 #endif
 
 #ifdef HAS_TANGENTS
-VERT_IN vec4 a_Tangent;
+  VERT_IN vec4 a_Tangent;
 #endif
 
 #ifdef HAS_NORMALS
-#ifdef HAS_TANGENTS
-VERT_OUT mat3 v_TBN;
-#else
-VERT_OUT vec3 v_Normal;
-#endif
+  #ifdef HAS_TANGENTS
+    VERT_OUT mat3 v_TBN;
+  #else
+    VERT_OUT vec3 v_Normal;
+  #endif
 #endif
 
 #ifdef HAS_UV_SET1
-VERT_IN vec2 a_UV1;
+  VERT_IN vec2 a_UV1;
 #endif
 
 #ifdef HAS_UV_SET2
-VERT_IN vec2 a_UV2;
+  VERT_IN vec2 a_UV2;
 #endif
 
 VERT_OUT vec2 v_UVCoord1;
 VERT_OUT vec2 v_UVCoord2;
 
 #ifdef HAS_VERTEX_COLOR_VEC3
-VERT_IN vec3 a_Color;
-VERT_OUT vec3 v_Color;
+  VERT_IN vec3 a_Color;
+  VERT_OUT vec3 v_Color;
 #endif
 
 #ifdef HAS_VERTEX_COLOR_VEC4
-VERT_IN vec4 a_Color;
-VERT_OUT vec4 v_Color;
+  VERT_IN vec4 a_Color;
+  VERT_OUT vec4 v_Color;
 #endif
 
 uniform mat4 u_ViewProjectionMatrix;
@@ -75,110 +77,104 @@ uniform mat4 u_ModelMatrix;
 uniform mat4 u_NormalMatrix;
 
 #ifdef USE_SHADOW_MAPPING
-uniform mat4 u_LightViewProjectionMatrix;
-VERT_OUT vec4 v_PositionLightSpace;
+  uniform mat4 u_LightViewProjectionMatrix;
+  VERT_OUT vec4 v_PositionLightSpace;
 #endif
 
 vec4 getPosition()
 {
-    vec4 pos = a_Position;
-
-#ifdef USE_MORPHING
+  vec4 pos = a_Position;
+  #ifdef USE_MORPHING
     pos += getTargetPosition();
-#endif
-
-#ifdef USE_SKINNING
+  #endif
+  #ifdef USE_SKINNING
     pos = getSkinningMatrix() * pos;
-#endif
-
-    return pos;
+  #endif
+  return pos;
 }
 
 #ifdef HAS_NORMALS
 vec4 getNormal()
 {
-    vec4 normal = a_Normal;
-
-#ifdef USE_MORPHING
+  vec4 normal = a_Normal;
+  #ifdef USE_MORPHING
     normal += getTargetNormal();
-#endif
-
-#ifdef USE_SKINNING
+  #endif
+  #ifdef USE_SKINNING
     normal = getSkinningNormalMatrix() * normal;
-#endif
-
-    return normalize(normal);
+  #endif
+  return normalize(normal);
 }
 #endif
 
 #ifdef HAS_TANGENTS
 vec4 getTangent()
 {
-    vec4 tangent = a_Tangent;
-
-#ifdef USE_MORPHING
+  vec4 tangent = a_Tangent;
+  #ifdef USE_MORPHING
     tangent += getTargetTangent();
-#endif
-
-#ifdef USE_SKINNING
+  #endif
+  #ifdef USE_SKINNING
     tangent = getSkinningMatrix() * tangent;
-#endif
-
-    return normalize(tangent);
+  #endif
+  return normalize(tangent);
 }
 #endif
 
 void main()
 {
-    mat4 modelMatrix = u_ModelMatrix;
-    #ifdef USE_INSTANCING
-        modelMatrix = mat4(a_ModelMatrix0, a_ModelMatrix1, a_ModelMatrix2, a_ModelMatrix3);
-    #endif
-    vec4 pos = modelMatrix * getPosition();
-    v_Position = vec3(pos.xyz) / pos.w;
+  mat4 modelMatrix = u_ModelMatrix;
+  #ifdef USE_INSTANCING
+    modelMatrix = mat4(a_ModelMatrix0, a_ModelMatrix1, a_ModelMatrix2, a_ModelMatrix3);
+  #endif
+  vec4 pos = modelMatrix * getPosition();
+  v_Position = vec3(pos.xyz) / pos.w;
 
-    mat4 normalMatrix = u_NormalMatrix;
-    #ifdef USE_INSTANCING
-        normalMatrix = mat4(a_NormalMatrix0, a_NormalMatrix1, a_NormalMatrix2, a_NormalMatrix3);
-    #endif
+  mat4 normalMatrix = u_NormalMatrix;
+  #ifdef USE_INSTANCING
+    normalMatrix = mat4(a_NormalMatrix0, a_NormalMatrix1, a_NormalMatrix2, a_NormalMatrix3);
+  #endif
 
-    #ifdef HAS_NORMALS
+  #ifdef HAS_NORMALS
     #ifdef HAS_TANGENTS
-    vec4 tangent = getTangent();
-    vec3 normalW = normalize(vec3(normalMatrix * vec4(getNormal().xyz, 0.0)));
-    vec3 tangentW = normalize(vec3(modelMatrix * vec4(tangent.xyz, 0.0)));
-    vec3 bitangentW = cross(normalW, tangentW) * tangent.w;
-    v_TBN = mat3(tangentW, bitangentW, normalW);
+      vec4 tangent = getTangent();
+      vec3 normalW = normalize(vec3(normalMatrix * vec4(getNormal().xyz, 0.0)));
+      vec3 tangentW = normalize(vec3(modelMatrix * vec4(tangent.xyz, 0.0)));
+      vec3 bitangentW = cross(normalW, tangentW) * tangent.w;
+      v_TBN = mat3(tangentW, bitangentW, normalW);
     #else // !HAS_TANGENTS
-    v_Normal = normalize(vec3(normalMatrix * vec4(getNormal().xyz, 0.0)));
+      v_Normal = normalize(vec3(normalMatrix * vec4(getNormal().xyz, 0.0)));
     #endif
-    #endif // !HAS_NORMALS
+  #endif // !HAS_NORMALS
 
-    v_UVCoord1 = vec2(0.0, 0.0);
-    v_UVCoord2 = vec2(0.0, 0.0);
-
-    #ifdef HAS_UV_SET1
+  v_UVCoord1 = vec2(0.0, 0.0);
+  v_UVCoord2 = vec2(0.0, 0.0);
+  #ifdef HAS_UV_SET1
     v_UVCoord1 = a_UV1;
-    #endif
-
-    #ifdef HAS_UV_SET2
+  #endif
+  #ifdef HAS_UV_SET2
     v_UVCoord2 = a_UV2;
-    #endif
+  #endif
 
-    #if defined(HAS_VERTEX_COLOR_VEC3) || defined(HAS_VERTEX_COLOR_VEC4)
+  #if defined(HAS_VERTEX_COLOR_VEC3) || defined(HAS_VERTEX_COLOR_VEC4)
     v_Color = a_Color;
-    #endif
+  #endif
 
-    #ifdef USE_SHADOW_MAPPING
+  #ifdef USE_SHADOW_MAPPING
     v_PositionLightSpace = u_LightViewProjectionMatrix * pos;
-    #endif
+  #endif
 
-    #ifdef USE_INSTANCING
+  #ifdef USE_INSTANCING
     v_BaseColorFactor = a_BaseColorFactor;
-        #ifdef HAS_BASE_COLOR_MAP
-        v_BaseColorUVTransform = mat3(a_BaseColorUVTransform0, a_BaseColorUVTransform1, a_BaseColorUVTransform2);
-        #endif
-    #endif
+  #endif
 
-    gl_Position = u_ViewProjectionMatrix * pos;
+  #ifdef HAS_SPRITESHEET
+    #ifdef USE_INSTANCING
+      v_BaseColorUVIndex = a_BaseColorUVIndex;
+    #else
+      v_BaseColorUVIndex = u_BaseColorUVIndex;
+    #endif
+  #endif
+
+  gl_Position = u_ViewProjectionMatrix * pos;
 }

--- a/src/material/standard/shader/primitive.vert
+++ b/src/material/standard/shader/primitive.vert
@@ -18,6 +18,12 @@ VERT_IN vec4 a_ModelMatrix3;
 #ifdef USE_INSTANCING
 VERT_IN vec4 a_BaseColorFactor;
 VERT_OUT vec4 v_BaseColorFactor;
+    #ifdef HAS_BASE_COLOR_MAP
+    VERT_IN vec3 a_BaseColorUVTransform0;
+    VERT_IN vec3 a_BaseColorUVTransform1;
+    VERT_IN vec3 a_BaseColorUVTransform2;
+    VERT_OUT mat3 v_BaseColorUVTransform;
+    #endif
 #endif
 
 #ifdef USE_INSTANCING
@@ -169,6 +175,9 @@ void main()
 
     #ifdef USE_INSTANCING
     v_BaseColorFactor = a_BaseColorFactor;
+        #ifdef HAS_BASE_COLOR_MAP
+        v_BaseColorUVTransform = mat3(a_BaseColorUVTransform0, a_BaseColorUVTransform1, a_BaseColorUVTransform2);
+        #endif
     #endif
 
     gl_Position = u_ViewProjectionMatrix * pos;

--- a/src/material/standard/shader/textures.glsl
+++ b/src/material/standard/shader/textures.glsl
@@ -28,6 +28,9 @@ uniform mat3 u_OcclusionUVTransform;
 uniform sampler2D u_BaseColorSampler;
 uniform int u_BaseColorUVSet;
 uniform mat3 u_BaseColorUVTransform;
+#ifdef USE_INSTANCING
+    FRAG_IN mat3 v_BaseColorUVTransform;
+#endif
 #endif
 
 #ifdef HAS_METALLIC_ROUGHNESS_MAP
@@ -102,8 +105,20 @@ vec2 getBaseColorUV()
     vec3 uv = vec3(v_UVCoord1, 1.0);
 #ifdef HAS_BASE_COLOR_MAP
     uv.xy = u_BaseColorUVSet < 1 ? v_UVCoord1 : v_UVCoord2;
+#endif
+#ifdef FLIP_UV_X
+    uv.x = 1.0 - uv.x;
+#endif
+#ifdef FLIP_UV_Y
+    uv.y = 1.0 - uv.y;
+#endif
+#ifdef HAS_BASE_COLOR_MAP
     #ifdef HAS_BASECOLOR_UV_TRANSFORM
-    uv = u_BaseColorUVTransform * uv;
+        #ifdef USE_INSTANCING
+        uv = v_BaseColorUVTransform * uv;
+        #else
+        uv = u_BaseColorUVTransform * uv;
+        #endif
     #endif
 #endif
     return uv.xy;

--- a/src/material/standard/shader/textures.glsl
+++ b/src/material/standard/shader/textures.glsl
@@ -23,14 +23,16 @@ uniform float u_OcclusionStrength;
 uniform mat3 u_OcclusionUVTransform;
 #endif
 
+#ifdef HAS_SPRITESHEET
+  uniform mat3 u_BaseColorUVTransforms[UV_COUNT];
+  FRAG_IN float v_BaseColorUVIndex;  
+#endif
+
 // Metallic Roughness Material
 #ifdef HAS_BASE_COLOR_MAP
 uniform sampler2D u_BaseColorSampler;
 uniform int u_BaseColorUVSet;
 uniform mat3 u_BaseColorUVTransform;
-#ifdef USE_INSTANCING
-    FRAG_IN mat3 v_BaseColorUVTransform;
-#endif
 #endif
 
 #ifdef HAS_METALLIC_ROUGHNESS_MAP
@@ -100,6 +102,8 @@ vec2 getOcclusionUV()
     return uv.xy;
 }
 
+
+
 vec2 getBaseColorUV()
 {
     vec3 uv = vec3(v_UVCoord1, 1.0);
@@ -113,12 +117,13 @@ vec2 getBaseColorUV()
     uv.y = 1.0 - uv.y;
 #endif
 #ifdef HAS_BASE_COLOR_MAP
-    #ifdef HAS_BASECOLOR_UV_TRANSFORM
-        #ifdef USE_INSTANCING
-        uv = v_BaseColorUVTransform * uv;
-        #else
+    #ifdef HAS_SPRITESHEET
+      highp int index = int(v_BaseColorUVIndex);
+      if(index > -1) {
+        uv = u_BaseColorUVTransforms[index] * uv;
+      }
+    #elif defined(HAS_BASECOLOR_UV_TRANSFORM)
         uv = u_BaseColorUVTransform * uv;
-        #endif
     #endif
 #endif
     return uv.xy;

--- a/src/material/standard/standard-material-feature-set.ts
+++ b/src/material/standard/standard-material-feature-set.ts
@@ -90,6 +90,12 @@ export namespace StandardMaterialFeatureSet {
     if (material.shadowCastingLight) {
       features.push("USE_SHADOW_MAPPING 1")
     }
+    if (material.baseColorSpriteSheet &&
+      material.baseColorSpriteSheet.baseTexture.valid &&
+      material.spritesheetTextures.length > 0) {
+      features.push(`HAS_SPRITESHEET 1`);
+      features.push(`UV_COUNT ${material.spritesheetTextures.length}`);
+    }
     if (material.baseColorTexture) {
       if (!material.baseColorTexture.valid) {
         return undefined

--- a/src/material/standard/standard-material-feature-set.ts
+++ b/src/material/standard/standard-material-feature-set.ts
@@ -145,6 +145,12 @@ export namespace StandardMaterialFeatureSet {
         break
       }
     }
+    if (material.flipX) {
+      features.push("FLIP_UV_X 1");
+    }
+    if (material.flipY) {
+      features.push("FLIP_UV_Y 1");
+    }
     if (material.debugMode) {
       features.push("DEBUG_OUTPUT 1")
     }

--- a/src/material/standard/standard-material.ts
+++ b/src/material/standard/standard-material.ts
@@ -45,6 +45,8 @@ export class StandardMaterial extends Material {
   private _metallicRoughnessTexture?: StandardMaterialTexture
   private _shadowCastingLight?: ShadowCastingLight
   private _instancingEnabled = false
+  private _flipX = false
+  private _flipY = false
 
   private _skinUniforms = new StandardMaterialSkinUniforms()
 
@@ -65,6 +67,7 @@ export class StandardMaterial extends Material {
 
   /** The exposure (brightness) of the material. */
   exposure = 1
+
 
   /** The base color texture. */
   get baseColorTexture() {
@@ -162,6 +165,30 @@ export class StandardMaterial extends Material {
     if (value !== this._shadowCastingLight) {
       this.invalidateShader()
       this._shadowCastingLight = value
+    }
+  }
+
+  /** Toggle flipping the UV's on the X axis */
+  get flipX() {
+    return this._flipX
+  }
+
+  set flipX(value: boolean) {
+    if (this._flipX !== value) {
+      this.invalidateShader()
+      this._flipX = value
+    }
+  }
+
+  /** Toggle flipping the UV's on the Y axis */
+  get flipY() {
+    return this._flipY
+  }
+
+  set flipY(value: boolean) {
+    if (this._flipY !== value) {
+      this.invalidateShader()
+      this._flipY = value
     }
   }
 

--- a/src/mesh/mesh-shader.ts
+++ b/src/mesh/mesh-shader.ts
@@ -65,6 +65,9 @@ export class MeshShader extends Shader {
     const instanceCount = mesh.instances.filter(i =>
       i.worldVisible && i.renderable).length
     const instancing = mesh.instances.length > 0
+    if (mesh.instanceOnly && instanceCount < 1) {
+      return;
+    }
     if (!mesh.geometry.hasShaderGeometry(this, instancing)) {
       mesh.geometry.addShaderGeometry(this, instancing)
     }

--- a/src/mesh/mesh.ts
+++ b/src/mesh/mesh.ts
@@ -34,6 +34,11 @@ export class Mesh3D extends Container3D {
   renderSortOrder = 0
 
   /**
+   * Specify that this mesh is to only draw the instances
+   */
+  instanceOnly = false
+
+  /**
    * Creates a new mesh with the specified geometry and material.
    * @param geometry The geometry for the mesh.
    * @param material The material for the mesh. If the material is empty the mesh won't be rendered.

--- a/src/model.ts
+++ b/src/model.ts
@@ -20,6 +20,11 @@ export class Model extends Container3D {
    */
   meshes: Mesh3D[] = []
 
+
+  setMeshInstancesOnly(value: boolean) {
+    this.meshes.forEach((mesh) => mesh.instanceOnly = value);
+  }
+
   /**
    * Creates a new model from a source.
    * @param source The source to create the model from.


### PR DESCRIPTION
### Features
- Ability to Flip X and Y on the texture UV's of a mesh, GLTF has a habit of flipping mesh UV's
- standard material can be supplied a spritesheet and instances supplied a texture which, so long as it corresponds to the spritesheet, should supply the instance with an index for accessing the corresponding UV transform for the texture
-  frag color was being incorrectly interpolated from full colour to black by its alpha