### PR TITLE
Sprite3D.zIndex should set internal ProjectionSprite.zIndex

### DIFF
--- a/src/sprite/sprite.ts
+++ b/src/sprite/sprite.ts
@@ -64,11 +64,11 @@ export class Sprite3D extends Container3D {
    * The zIndex of the sprite.
    * A higher value will mean it will be rendered on top of other sprites within the same container.
    */
-  get zIndex() {
+  get renderSortOrder() {
     return this._sprite.zIndex;
   }
 
-  set zIndex(value: number) {
+  set renderSortOrder(value: number) {
     this._sprite.zIndex = value;
   }
 

--- a/src/sprite/sprite.ts
+++ b/src/sprite/sprite.ts
@@ -61,6 +61,18 @@ export class Sprite3D extends Container3D {
   }
 
   /**
+   * The zIndex of the sprite.
+   * A higher value will mean it will be rendered on top of other sprites within the same container.
+   */
+  get zIndex() {
+    return this._sprite.zIndex;
+  }
+
+  set zIndex(value: number) {
+    this._sprite.zIndex = value;
+  }
+
+  /**
    * The tint applied to the sprite. This is a hex value. A value of 0xFFFFFF 
    * will remove any tint effect.
    */


### PR DESCRIPTION
The standard pipeline sorts its ProjectionSprites by zIndex, but as far as I can tell, there is no way to set this internal ProjectionSprite zIndex value through Sprite3D.