### PR TITLE
#53 Made CameraOrbitControl support touchscreen

### DIFF
--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -310,27 +310,14 @@ export class CameraOrbitControl {
    * Updates the position and rotation of the camera.
    */
   updateCamera(): void {
-    const angles = this.enableDamping ? this._dampingAngles : this._orbit
-    const distance = this.enableDamping
-      ? this._dampingDistance
-      : this._distance
+    let angles = this.enableDamping ? this._dampingAngles : this._angles
+    let distance = this.enableDamping ? this._dampingDistance : this._distance
 
-    const rot = Quat.fromEuler(angles.x, angles.y, 0, new Float32Array(4))
-    const dir = Vec3.transformQuat(
-      Vec3.set(0, 0, 1, new Float32Array(3)),
-      rot,
-      new Float32Array(3)
-    )
-    const pos = Vec3.subtract(
-      Vec3.set(
-        this.target.x,
-        this.target.y,
-        this.target.z,
-        new Float32Array(3)
-      ),
-      Vec3.scale(dir, distance, new Float32Array(3)),
-      new Float32Array(3)
-    )
+    let rot = Quat.fromEuler(angles.x, angles.y, 0, new Float32Array(4))
+    let dir = Vec3.transformQuat(
+      Vec3.set(0, 0, 1, new Float32Array(3)), rot, new Float32Array(3))
+    let pos = Vec3.subtract(
+      Vec3.set(this.target.x, this.target.y, this.target.z, new Float32Array(3)), Vec3.scale(dir, distance, new Float32Array(3)), new Float32Array(3))
 
     this.camera.position.set(pos[0], pos[1], pos[2])
     this.camera.rotationQuaternion.set(rot[0], rot[1], rot[2], rot[3])

--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -143,17 +143,17 @@ export class CameraOrbitControl {
     this.unbind()
   }
 
-  onPointerDown = (e: PointerEvent): void => {
+  protected onPointerDown = (e: PointerEvent): void => {
     this._grabbed = true
     this._previousClientX = e.clientX
     this._previousClientY = e.clientY
   }
 
-  onPointerUp = (): void => {
+  protected onPointerUp = (): void => {
     this._grabbed = false
   }
 
-  onPointerMove = (e: PointerEvent): void => {
+  protected onPointerMove = (e: PointerEvent): void => {
     if (this._grabbed) {
       const movementX = e.clientX - this._previousClientX
       const movementY = e.clientY - this._previousClientY
@@ -165,13 +165,13 @@ export class CameraOrbitControl {
     }
   }
 
-  onPreRender = (): void => {
+  protected onPreRender = (): void => {
     if (this.autoUpdate) {
       this.updateCamera()
     }
   }
 
-  onMouseDownInteraction = (e: InteractionEvent): void => {
+  protected onMouseDownInteraction = (e: InteractionEvent): void => {
     if (this.allowControl) {
       if (!e.stopped) {
         this._grabbed = true
@@ -190,13 +190,13 @@ export class CameraOrbitControl {
     }
   }
 
-  onMouseDown = (e: MouseEvent): void => {
+  protected onMouseDown = (e: MouseEvent): void => {
     if (this.allowControl) {
       this.onPointerDown(e as PointerEvent)
     }
   }
 
-  onMouseMove = (e: MouseEvent): void => {
+  protected onMouseMove = (e: MouseEvent): void => {
     if (this.allowControl) {
       if (e.buttons === 1) {
         this.onPointerMove(e as PointerEvent)
@@ -204,13 +204,13 @@ export class CameraOrbitControl {
     }
   }
 
-  onMouseUp = (_e: MouseEvent): void => {
+  protected onMouseUp = (_e: MouseEvent): void => {
     if (this.allowControl) {
       this.onPointerUp()
     }
   }
 
-  onWheel = (e: WheelEvent): void => {
+  protected onWheel = (e: WheelEvent): void => {
     if (this.allowControl) {
       this.distance += e.deltaY * 0.01
       e.preventDefault()
@@ -218,7 +218,7 @@ export class CameraOrbitControl {
     }
   }
 
-  onTouchStart = (e: TouchEvent): void => {
+  protected onTouchStart = (e: TouchEvent): void => {
     if (this.allowControl) {
       const touch = e?.targetTouches?.[0]
       if (touch) {
@@ -240,7 +240,7 @@ export class CameraOrbitControl {
     }
   }
 
-  onPinch = (e: TouchEvent): void => {
+  protected onPinch = (e: TouchEvent): void => {
     if (this.allowControl) {
       e.preventDefault() // Prevent page scroll
       const currentPinchDistance = Math.hypot(
@@ -255,7 +255,7 @@ export class CameraOrbitControl {
     }
   }
 
-  onTouchMove = (e: TouchEvent): void => {
+  protected onTouchMove = (e: TouchEvent): void => {
     if (this.allowControl) {
       const touch = e?.targetTouches?.[0]
       if (e.touches.length === 1 && touch) {
@@ -273,7 +273,7 @@ export class CameraOrbitControl {
     }
   }
 
-  onTouchEnd = (e: TouchEvent): void => {
+  protected onTouchEnd = (e: TouchEvent): void => {
     if (this.allowControl) {
       if (e.touches.length === 0) {
         this.onPointerUp()

--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -281,6 +281,33 @@ export class CameraOrbitControl {
     }
   }
 
+  protected bind(): void {
+    this.camera.renderer.on("prerender", this.onPreRender)
+    let interaction = Compatibility.getInteractionPlugin(this.camera.renderer)
+    if (interaction) {
+      interaction.on("mousedown", this.onMouseDownInteraction)
+    }
+    this._element.addEventListener("mousedown", this.onMouseDown)
+    this._element.addEventListener("touchstart", this.onTouchStart)
+    this._element.addEventListener("wheel", this.onWheel)
+    // Bind mouse and touch equivalent pointermove and pointerup events to window
+    // to support the case where the pointer leaves the element while dragging
+    window.addEventListener("mousemove", this.onMouseMove)
+    window.addEventListener("touchmove", this.onTouchMove)
+    window.addEventListener("mouseup", this.onMouseUp)
+    window.addEventListener("touchend", this.onTouchEnd)
+  }
+
+  protected unbind(): void {
+    this._element.removeEventListener("mousedown", this.onMouseDown)
+    this._element.removeEventListener("touchstart", this.onTouchStart)
+    this._element.removeEventListener("wheel", this.onWheel)
+    window.removeEventListener("mousemove", this.onMouseMove)
+    window.removeEventListener("touchmove", this.onTouchMove)
+    window.removeEventListener("mouseup", this.onMouseUp)
+    window.removeEventListener("touchend", this.onTouchEnd)
+  }
+  
   /**
    * Updates the position and rotation of the camera.
    */
@@ -307,32 +334,5 @@ export class CameraOrbitControl {
 
     this.camera.position.set(pos[0], pos[1], pos[2])
     this.camera.rotationQuaternion.set(rot[0], rot[1], rot[2], rot[3])
-  }
-
-  protected bind(): void {
-    this.camera.renderer.on("prerender", this.onPreRender)
-    let interaction = Compatibility.getInteractionPlugin(this.camera.renderer)
-    if (interaction) {
-      interaction.on("mousedown", this.onMouseDownInteraction)
-    }
-    this._element.addEventListener("mousedown", this.onMouseDown)
-    this._element.addEventListener("touchstart", this.onTouchStart)
-    this._element.addEventListener("wheel", this.onWheel)
-    // Bind mouse and touch equivalent pointermove and pointerup events to window
-    // to support the case where the pointer leaves the element while dragging
-    window.addEventListener("mousemove", this.onMouseMove)
-    window.addEventListener("touchmove", this.onTouchMove)
-    window.addEventListener("mouseup", this.onMouseUp)
-    window.addEventListener("touchend", this.onTouchEnd)
-  }
-
-  protected unbind(): void {
-    this._element.removeEventListener("mousedown", this.onMouseDown)
-    this._element.removeEventListener("touchstart", this.onTouchStart)
-    this._element.removeEventListener("wheel", this.onWheel)
-    window.removeEventListener("mousemove", this.onMouseMove)
-    window.removeEventListener("touchmove", this.onTouchMove)
-    window.removeEventListener("mouseup", this.onMouseUp)
-    window.removeEventListener("touchend", this.onTouchEnd)
   }
 }

--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -71,6 +71,10 @@ export class CameraOrbitControl {
     return this._angles
   }
 
+  set angles(value: { x: number; y: number; }) {
+    this._angles = value
+  }
+
   protected _distance = 5
 
   /**

--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -1,114 +1,365 @@
-import { ObservablePoint } from "@pixi/math"
 import type { InteractionEvent } from "@pixi/interaction"
-import { Camera } from "./camera"
+import { ObservablePoint } from "@pixi/math"
+import { Compatibility } from "../compatibility/compatibility"
 import { Quat } from "../math/quat"
 import { Vec3 } from "../math/vec3"
-import { Compatibility } from "../compatibility/compatibility"
+import { Camera } from "./camera"
 
 /**
  * Allows the user to control the camera by orbiting the target.
  */
 export class CameraOrbitControl {
-  private _grabbed = false
+  protected _autoUpdate = true;
 
-  private _dampingAngles = new ObservablePoint(() => { }, undefined, 0, 180)
+  /** 
+   * Whether to auto update the camera on prerender.
+   * Default is true.
+   */
+  get autoUpdate(): boolean {
+    return this._autoUpdate
+  }
 
-  private _distance = 5
-  private _dampingDistance = 5
+  set autoUpdate(value: boolean) {
+    this._autoUpdate = value
+  }
 
-  private _angles = new ObservablePoint(() => {
-    this._angles.x = Math.min(Math.max(-85, this._angles.x), 85)
-  }, undefined, 0, 180)
+  protected _controllable = true
+
+  /** 
+   * Allows the camera to be controlled by user.
+   */
+  get controllable(): boolean {
+    return this._controllable
+  }
+
+  set controllable(value: boolean) {
+    this._controllable = value
+  }
+
+  protected _camera = Camera.main
+
+  /** 
+   * The camera being controlled.
+   */
+  get camera(): Camera {
+    return this._camera
+  }
+
+  set camera(value: Camera) {
+    this._camera = value
+  }
+
+  protected _target = { x: 0, y: 0, z: 0 }
+
+  /** 
+   * Target position (x, y, z) to orbit.
+   */
+  get target(): { x: number; y: number; z: number } {
+    return this._target
+  }
+
+  protected _orbit = { x: 0, y: 180 }
+
+  private _angles = new ObservablePoint(
+    () => {
+      this._orbit.x = Math.min(Math.max(-85, this._orbit.x), 85)
+    },
+    undefined,
+    0,
+    180
+  )
 
   /**
-   * Orientation euler angles (x-axis and y-axis). The angle for the x-axis 
-   * will be clamped between -85 and 85 degrees.
+   * Orientation euler angles (x-axis and y-axis).
+   * The angle for the x-axis will be clamped between -85 and 85 degrees.
    */
-  get angles() {
+  get angles(): ObservablePoint {
     return this._angles
   }
 
-  /** Value indicating if damping (inertia) is enabled, which can be used to give a sense of weight to the controls. Default is false. */
-  enableDamping = false
+  protected _distance = 5
 
-  /** The damping inertia used if enableDamping is true. Default is 0.1. */
-  dampingFactor = 0.1
+  /**
+   * Distance between camera and the target.
+   * Default value is 5.
+   */
+  get distance(): number {
+    return this._distance
+  }
 
-  /** Target position (x, y, z) to orbit. */
-  target = { x: 0, y: 0, z: 0 }
+  set distance(value: number) {
+    this._distance = Math.min(Math.max(value, 0.01), Number.MAX_SAFE_INTEGER)
+  }
 
-  /** Allows the camera to be controlled by user. */
-  allowControl = true
+  protected _enableDamping = false
+  
+  /** 
+   * Value indicating if damping (inertia) is enabled, which can be used to give a sense of weight to the controls.
+   * Default is false.
+   */
+  get enableDamping(): boolean {
+    return this._enableDamping
+  }
+
+  set enableDamping(value: boolean) {
+    this._enableDamping = value
+  }
+
+  protected _dampingFactor = 0.1
+  
+  /** 
+   * The damping inertia used if enableDamping is true.
+   * Default is 0.1.
+   */
+  get dampingFactor(): number {
+    return this._dampingFactor
+  }
+
+  set dampingFactor(value: number) {
+    this._dampingFactor = value
+  }
+
+  protected _element: HTMLElement
+
+  protected _grabbed = false
+
+  protected _previousPinchDistance = 0
+
+  protected _previousClientX = 0
+
+  protected _previousClientY = 0
+
+  protected _dampingAngles = new ObservablePoint(() => null, undefined, 0, 180)
+
+  protected _dampingDistance = 5
 
   /**
    * Creates a new camera orbit control.
    * @param element The element for listening to user events.
-   * @param camera The camera to control. If not set, the main camera will be used 
+   * @param camera The camera to control. If not set, the main camera will be used
    * by default.
    */
-  constructor(element: HTMLElement, public camera = Camera.main) {
-    this.camera.renderer.on("prerender", () => {
+  constructor(element: HTMLElement, camera = Camera.main) {
+    this._element = element
+    this._camera = camera
+    this.bind()
+  }
+
+  destroy(): void {
+    this.unbind()
+  }
+
+  onPointerDown = (e: PointerEvent): void => {
+    this._grabbed = true
+    this._previousClientX = e.clientX
+    this._previousClientY = e.clientY
+  }
+
+  onPointerUp = (): void => {
+    this._grabbed = false
+  }
+
+  onPointerMove = (e: PointerEvent): void => {
+    if (this._grabbed) {
+      const movementX = e.clientX - this._previousClientX
+      const movementY = e.clientY - this._previousClientY
+      this._orbit.x += movementY * 0.5
+      this._orbit.y -= movementX * 0.5
       if (this.enableDamping) {
-        this._dampingAngles.x = this._dampingAngles.x + (this._angles.x - this._dampingAngles.x) * this.dampingFactor
-        this._dampingAngles.y = this._dampingAngles.y + (this._angles.y - this._dampingAngles.y) * this.dampingFactor
-        this._dampingDistance = this._dampingDistance + (this._distance - this._dampingDistance) * this.dampingFactor
+        this.damp()
       }
       this.updateCamera()
-    })
-    let interaction = Compatibility.getInteractionPlugin(this.camera.renderer)
-    if (interaction) {
-      interaction.on("mousedown", (e: InteractionEvent) => {
-        if (!e.stopped) {
-          this._grabbed = true
-        }
-      })
+      this._previousClientX = e.clientX
+      this._previousClientY = e.clientY
     }
-    element.addEventListener("mousedown", () => {
+  }
+
+  onPreRender = (): void => {
+    if (this.autoUpdate) {
+      if (this.enableDamping) {
+        this.damp()
+      }
+      this.updateCamera()
+    }
+  }
+
+  onMouseDownInteraction = (e: InteractionEvent): void => {
+    if (!e.stopped) {
       this._grabbed = true
-    })
-    element.addEventListener("mouseup", () => {
-      this._grabbed = false
-    })
-    element.addEventListener("mousemove", (event) => {
-      if (this.allowControl && event.buttons === 1 && this._grabbed) {
-        this._angles.x += event.movementY * 0.5
-        this._angles.y -= event.movementX * 0.5
+      const originalEvent = e.data.originalEvent
+      const touchEvent = originalEvent as TouchEvent
+      const mouseEvent = originalEvent as MouseEvent
+      const touch = touchEvent?.targetTouches?.[0]
+      const pointerEvent = originalEvent as unknown as {
+        clientX: number
+        clientY: number
       }
-    })
-    element.addEventListener("wheel", (event) => {
-      if (this.allowControl) {
-        this.distance += event.deltaY * 0.01
-        event.preventDefault()
+      pointerEvent.clientX = touch?.clientX ?? mouseEvent?.clientX
+      pointerEvent.clientY = touch?.clientY ?? mouseEvent?.clientY
+      this.onPointerDown(pointerEvent as PointerEvent)
+    }
+  }
+
+  onMouseDown = (e: MouseEvent): void => {
+    if (this.controllable) {
+      this.onPointerDown(e as PointerEvent)
+    }
+  }
+
+  onMouseMove = (e: MouseEvent): void => {
+    if (this.controllable) {
+      if (e.buttons === 1) {
+        this.onPointerMove(e as PointerEvent)
       }
-    })
+    }
+  }
+
+  onMouseUp = (_e: MouseEvent): void => {
+    if (this.controllable) {
+      this.onPointerUp()
+    }
+  }
+
+  onWheel = (e: WheelEvent): void => {
+    if (this.controllable) {
+      this.distance += e.deltaY * 0.01
+      e.preventDefault()
+      if (this.enableDamping) {
+        this.damp()
+      }
+      this.updateCamera()
+    }
+  }
+
+  onTouchStart = (e: TouchEvent): void => {
+    if (this.controllable) {
+      const touch = e?.targetTouches?.[0]
+      if (touch) {
+        const pointerEvent = e as unknown as {
+          clientX: number
+          clientY: number
+        }
+        pointerEvent.clientX = touch.clientX
+        pointerEvent.clientY = touch.clientY
+        this.onPointerDown(pointerEvent as PointerEvent)
+      }
+      if (e.touches.length === 2) {
+        e.preventDefault() // Prevent page scroll
+        this._previousPinchDistance = Math.hypot(
+          e.touches[0].clientX - e.touches[1].clientX,
+          e.touches[0].clientY - e.touches[1].clientY
+        )
+      }
+    }
+  }
+
+  onPinch = (e: TouchEvent): void => {
+    if (this.controllable) {
+      e.preventDefault() // Prevent page scroll
+      const currentPinchDistance = Math.hypot(
+        e.touches[0].clientX - e.touches[1].clientX,
+        e.touches[0].clientY - e.touches[1].clientY
+      )
+      const deltaPinchDistance =
+        currentPinchDistance - this._previousPinchDistance
+      this.distance -= deltaPinchDistance * 0.1
+      if (this.enableDamping) {
+        this.damp()
+      }
+      this.updateCamera()
+      this._previousPinchDistance = currentPinchDistance
+    }
+  }
+
+  onTouchMove = (e: TouchEvent): void => {
+    if (this.controllable) {
+      const touch = e?.targetTouches?.[0]
+      if (e.touches.length === 1 && touch) {
+        const pointerEvent = e as unknown as {
+          clientX: number
+          clientY: number
+        }
+        pointerEvent.clientX = touch.clientX
+        pointerEvent.clientY = touch.clientY
+        this.onPointerMove(pointerEvent as PointerEvent)
+      }
+      if (e.touches.length === 2) {
+        this.onPinch(e)
+      }
+    }
+  }
+
+  onTouchEnd = (e: TouchEvent): void => {
+    if (this.controllable) {
+      if (e.touches.length === 0) {
+        this.onPointerUp()
+      }
+    }
+  }
+
+  damp(): void {
+    this._dampingAngles.x +=
+      (this._orbit.x - this._dampingAngles.x) * this.dampingFactor
+    this._dampingAngles.y +=
+      (this._orbit.y - this._dampingAngles.y) * this.dampingFactor
+    this._dampingDistance +=
+      (this._distance - this._dampingDistance) * this.dampingFactor
   }
 
   /**
    * Updates the position and rotation of the camera.
    */
-  updateCamera() {
-    let angles = this.enableDamping ? this._dampingAngles : this._angles
-    let distance = this.enableDamping ? this._dampingDistance : this._distance
+  updateCamera(): void {
+    const angles = this.enableDamping ? this._dampingAngles : this._orbit
+    const distance = this.enableDamping
+      ? this._dampingDistance
+      : this._distance
 
-    let rot = Quat.fromEuler(angles.x, angles.y, 0, new Float32Array(4))
-    let dir = Vec3.transformQuat(
-      Vec3.set(0, 0, 1, new Float32Array(3)), rot, new Float32Array(3))
-    let pos = Vec3.subtract(
-      Vec3.set(this.target.x, this.target.y, this.target.z, new Float32Array(3)), Vec3.scale(dir, distance, new Float32Array(3)), new Float32Array(3))
+    const rot = Quat.fromEuler(angles.x, angles.y, 0, new Float32Array(4))
+    const dir = Vec3.transformQuat(
+      Vec3.set(0, 0, 1, new Float32Array(3)),
+      rot,
+      new Float32Array(3)
+    )
+    const pos = Vec3.subtract(
+      Vec3.set(
+        this.target.x,
+        this.target.y,
+        this.target.z,
+        new Float32Array(3)
+      ),
+      Vec3.scale(dir, distance, new Float32Array(3)),
+      new Float32Array(3)
+    )
 
     this.camera.position.set(pos[0], pos[1], pos[2])
     this.camera.rotationQuaternion.set(rot[0], rot[1], rot[2], rot[3])
   }
 
-  /**
-   * Distance between camera and the target. Default value is 5.
-   */
-  get distance() {
-    return this._distance
+  bind(): void {
+    this.camera.renderer.on("prerender", this.onPreRender)
+    let interaction = Compatibility.getInteractionPlugin(this.camera.renderer)
+    if (interaction) {
+      interaction.on("mousedown", this.onMouseDownInteraction)
+    }
+    this._element.addEventListener("mousedown", this.onMouseDown)
+    this._element.addEventListener("touchstart", this.onTouchStart)
+    this._element.addEventListener("wheel", this.onWheel)
+    // Bind mouse and touch equivalent pointermove and pointerup events to window
+    // to support the case where the pointer leaves the element while dragging
+    window.addEventListener("mousemove", this.onMouseMove)
+    window.addEventListener("touchmove", this.onTouchMove)
+    window.addEventListener("mouseup", this.onMouseUp)
+    window.addEventListener("touchend", this.onTouchEnd)
   }
 
-  set distance(value: number) {
-    this._distance = Math.min(
-      Math.max(value, 0.01), Number.MAX_SAFE_INTEGER)
+  unbind(): void {
+    this._element.removeEventListener("mousedown", this.onMouseDown)
+    this._element.removeEventListener("touchstart", this.onTouchStart)
+    this._element.removeEventListener("wheel", this.onWheel)
+    window.removeEventListener("mousemove", this.onMouseMove)
+    window.removeEventListener("touchmove", this.onTouchMove)
+    window.removeEventListener("mouseup", this.onMouseUp)
+    window.removeEventListener("touchend", this.onTouchEnd)
   }
 }

--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -23,17 +23,17 @@ export class CameraOrbitControl {
     this._autoUpdate = value
   }
 
-  protected _controllable = true
+  protected _allowControl = true
 
   /** 
    * Allows the camera to be controlled by user.
    */
-  get controllable(): boolean {
-    return this._controllable
+  get allowControl(): boolean {
+    return this._allowControl
   }
 
-  set controllable(value: boolean) {
-    this._controllable = value
+  set allowControl(value: boolean) {
+    this._allowControl = value
   }
 
   protected _camera = Camera.main
@@ -201,13 +201,13 @@ export class CameraOrbitControl {
   }
 
   onMouseDown = (e: MouseEvent): void => {
-    if (this.controllable) {
+    if (this.allowControl) {
       this.onPointerDown(e as PointerEvent)
     }
   }
 
   onMouseMove = (e: MouseEvent): void => {
-    if (this.controllable) {
+    if (this.allowControl) {
       if (e.buttons === 1) {
         this.onPointerMove(e as PointerEvent)
       }
@@ -215,13 +215,13 @@ export class CameraOrbitControl {
   }
 
   onMouseUp = (_e: MouseEvent): void => {
-    if (this.controllable) {
+    if (this.allowControl) {
       this.onPointerUp()
     }
   }
 
   onWheel = (e: WheelEvent): void => {
-    if (this.controllable) {
+    if (this.allowControl) {
       this.distance += e.deltaY * 0.01
       e.preventDefault()
       if (this.enableDamping) {
@@ -232,7 +232,7 @@ export class CameraOrbitControl {
   }
 
   onTouchStart = (e: TouchEvent): void => {
-    if (this.controllable) {
+    if (this.allowControl) {
       const touch = e?.targetTouches?.[0]
       if (touch) {
         const pointerEvent = e as unknown as {
@@ -254,7 +254,7 @@ export class CameraOrbitControl {
   }
 
   onPinch = (e: TouchEvent): void => {
-    if (this.controllable) {
+    if (this.allowControl) {
       e.preventDefault() // Prevent page scroll
       const currentPinchDistance = Math.hypot(
         e.touches[0].clientX - e.touches[1].clientX,
@@ -272,7 +272,7 @@ export class CameraOrbitControl {
   }
 
   onTouchMove = (e: TouchEvent): void => {
-    if (this.controllable) {
+    if (this.allowControl) {
       const touch = e?.targetTouches?.[0]
       if (e.touches.length === 1 && touch) {
         const pointerEvent = e as unknown as {
@@ -290,7 +290,7 @@ export class CameraOrbitControl {
   }
 
   onTouchEnd = (e: TouchEvent): void => {
-    if (this.controllable) {
+    if (this.allowControl) {
       if (e.touches.length === 0) {
         this.onPointerUp()
       }

--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -1,5 +1,4 @@
 import type { InteractionEvent } from "@pixi/interaction"
-import { ObservablePoint } from "@pixi/math"
 import { Compatibility } from "../compatibility/compatibility"
 import { Quat } from "../math/quat"
 import { Vec3 } from "../math/vec3"
@@ -124,7 +123,7 @@ export class CameraOrbitControl {
 
   protected _previousClientY = 0
 
-  protected _dampingAngles = new ObservablePoint(() => null, undefined, 0, 180)
+  protected _dampingAngles = { x: 0, y: 180 }
 
   protected _dampingDistance = 5
 

--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -172,19 +172,21 @@ export class CameraOrbitControl {
   }
 
   onMouseDownInteraction = (e: InteractionEvent): void => {
-    if (!e.stopped) {
-      this._grabbed = true
-      const originalEvent = e.data.originalEvent
-      const touchEvent = originalEvent as TouchEvent
-      const mouseEvent = originalEvent as MouseEvent
-      const touch = touchEvent?.targetTouches?.[0]
-      const pointerEvent = originalEvent as unknown as {
-        clientX: number
-        clientY: number
+    if (this.allowControl) {
+      if (!e.stopped) {
+        this._grabbed = true
+        const originalEvent = e.data.originalEvent
+        const touchEvent = originalEvent as TouchEvent
+        const mouseEvent = originalEvent as MouseEvent
+        const touch = touchEvent?.targetTouches?.[0]
+        const pointerEvent = originalEvent as unknown as {
+          clientX: number
+          clientY: number
+        }
+        pointerEvent.clientX = touch?.clientX ?? mouseEvent?.clientX
+        pointerEvent.clientY = touch?.clientY ?? mouseEvent?.clientY
+        this.onPointerDown(pointerEvent as PointerEvent)
       }
-      pointerEvent.clientX = touch?.clientX ?? mouseEvent?.clientX
-      pointerEvent.clientY = touch?.clientY ?? mouseEvent?.clientY
-      this.onPointerDown(pointerEvent as PointerEvent)
     }
   }
 

--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -309,7 +309,7 @@ export class CameraOrbitControl {
     this.camera.rotationQuaternion.set(rot[0], rot[1], rot[2], rot[3])
   }
 
-  bind(): void {
+  protected bind(): void {
     this.camera.renderer.on("prerender", this.onPreRender)
     let interaction = Compatibility.getInteractionPlugin(this.camera.renderer)
     if (interaction) {
@@ -326,7 +326,7 @@ export class CameraOrbitControl {
     window.addEventListener("touchend", this.onTouchEnd)
   }
 
-  unbind(): void {
+  protected unbind(): void {
     this._element.removeEventListener("mousedown", this.onMouseDown)
     this._element.removeEventListener("touchstart", this.onTouchStart)
     this._element.removeEventListener("wheel", this.onWheel)

--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -61,14 +61,14 @@ export class CameraOrbitControl {
     this._target = value
   }
 
-  protected _orbit = { x: 0, y: 180 }
+  protected _angles = { x: 0, y: 180 }
 
   /**
    * Orientation euler angles (x-axis and y-axis).
    * The angle for the x-axis will be clamped between -85 and 85 degrees.
    */
   get angles(): { x: number; y: number; } {
-    return this._orbit
+    return this._angles
   }
 
   protected _distance = 5
@@ -285,7 +285,7 @@ export class CameraOrbitControl {
    * Updates the position and rotation of the camera.
    */
   updateCamera(): void {
-    this._orbit.x = Math.min(Math.max(-85, this._orbit.x), 85)
+    this._angles.x = Math.min(Math.max(-85, this._angles.x), 85)
     
     if (this.enableDamping) {
       this._dampingAngles.x +=

--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -58,6 +58,10 @@ export class CameraOrbitControl {
     return this._target
   }
 
+  set target(value: { x: number; y: number; z: number }) {
+    this._target = value
+  }
+
   protected _orbit = { x: 0, y: 180 }
 
   private _angles = new ObservablePoint(

--- a/src/camera/camera-orbit-control.ts
+++ b/src/camera/camera-orbit-control.ts
@@ -167,8 +167,8 @@ export class CameraOrbitControl {
     if (this._grabbed) {
       const movementX = e.clientX - this._previousClientX
       const movementY = e.clientY - this._previousClientY
-      this._orbit.x += movementY * 0.5
-      this._orbit.y -= movementX * 0.5
+      this.angles.x += movementY * 0.5
+      this.angles.y -= movementX * 0.5
       if (this.enableDamping) {
         this.damp()
       }
@@ -303,19 +303,19 @@ export class CameraOrbitControl {
 
   damp(): void {
     this._dampingAngles.x +=
-      (this._orbit.x - this._dampingAngles.x) * this.dampingFactor
+      (this.angles.x - this._dampingAngles.x) * this.dampingFactor
     this._dampingAngles.y +=
-      (this._orbit.y - this._dampingAngles.y) * this.dampingFactor
+      (this.angles.y - this._dampingAngles.y) * this.dampingFactor
     this._dampingDistance +=
-      (this._distance - this._dampingDistance) * this.dampingFactor
+      (this.distance - this._dampingDistance) * this.dampingFactor
   }
 
   /**
    * Updates the position and rotation of the camera.
    */
   updateCamera(): void {
-    let angles = this.enableDamping ? this._dampingAngles : this._angles
-    let distance = this.enableDamping ? this._dampingDistance : this._distance
+    let angles = this.enableDamping ? this._dampingAngles : this.angles
+    let distance = this.enableDamping ? this._dampingDistance : this.distance
 
     let rot = Quat.fromEuler(angles.x, angles.y, 0, new Float32Array(4))
     let dir = Vec3.transformQuat(


### PR DESCRIPTION
(Also added autoUpdate and camera accessor properties so these can be changed after instantiation. It's a small change, but I can separate it out into another PR if necessary.)

Our engine runs on both desktop and mobile devices so I needed CameraOrbitControl to support touch screen events.

To test:
1. Run on touch screen device.
2. Drag with one finger to change camera angle.
3. Pinch-and-zoom with two fingers to change camera distance.